### PR TITLE
fix: attach runtime info by default in go

### DIFF
--- a/clients/go/pkg/auditopt/config.go
+++ b/clients/go/pkg/auditopt/config.go
@@ -91,7 +91,7 @@ func FromConfigFile(path string) audit.Option {
 }
 
 func configureClientFromViper(c *audit.Client, v *viper.Viper) error {
-	var opts []audit.Option
+	opts := []audit.Option{audit.WithRuntimeInfo()}
 
 	withPrincipalFilter, err := principalFilterFromViper(v)
 	if err != nil {


### PR DESCRIPTION
Fix for: https://github.com/abcxyz/lumberjack/issues/5