### PR TITLE
fix: Recreate CI env and decouple it from CI runs

### DIFF
--- a/scripts/integration_build.sh
+++ b/scripts/integration_build.sh
@@ -17,18 +17,16 @@
 set -eEuo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
-TF_ENVS_CI_DIR=${ROOT}/terraform/envs/ci
 TF_CI_WITH_SERVER_DIR=${ROOT}/terraform/ci-run-with-server
 SERVICE_NAME=ci-with-server-${RANDOM}
 GO_BUILD_COMMAND=${ROOT}/clients/go/test/shell/build.sh
 JAVA_BUILD_COMMAND=${ROOT}/clients/java-logger/scripts/build_shell.sh
 
-terraform -chdir=${TF_ENVS_CI_DIR} init
-terraform -chdir=${TF_ENVS_CI_DIR} apply -auto-approve
-
-SHELL_APP_PROJECT_ID=$(terraform -chdir=${TF_ENVS_CI_DIR} output -raw app_project)
-BACKEND_PROJECT_ID=$(terraform -chdir=${TF_ENVS_CI_DIR} output -raw server_project)
-BIGQUERY_DATASET_ID=$(terraform -chdir=${TF_ENVS_CI_DIR} output -raw bigquery_dataset_id)
+# Hardcode these values.
+# Re-applying the CI env in each CI run might cause unexpected changes being applied to the CI env.
+SHELL_APP_PROJECT_ID=github-ci-app-0
+BACKEND_PROJECT_ID=github-ci-server
+BIGQUERY_DATASET_ID=audit_logs
 
 KOKORO_SERVICE_ACCOUNT=kokoro-sa@lumberjack-kokoro.iam.gserviceaccount.com
 GCLOUD_ACCOUNT=$(gcloud config get-value account)

--- a/terraform/envs/ci/.terraform.lock.hcl
+++ b/terraform/envs/ci/.terraform.lock.hcl
@@ -2,40 +2,38 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version = "4.0.0"
+  version = "4.6.0"
   hashes = [
-    "h1:9Wx5zZikv9lvMzt119deXAnzyNsEcqtA4ifE8MYN0e8=",
-    "h1:knAWmZ1uR3JYwsm9ZtAMAg3tPMw2wpj+FI6goEv+jm4=",
-    "zh:48fbf905a5c1658b042c7edb0183e9a25dc04257cd5e6d4d870b33a0bc70eda4",
-    "zh:5f7a1579e23f0d187cc9062ec54f30d7336252705d4e0dd9dbd799cebd83429b",
-    "zh:63bb8f094eec5cecf1acbe7026c0ba31126670282dbcfce01477aec6c134a3bd",
-    "zh:7654b20e5dc0ed595f084039e8fd49ff70c11e2ed7b9fcc9c6169f3217845adb",
-    "zh:7bc37430171b2148b2bb835dc2eff967714d2ac515e73784b66c2ddda6d260fa",
-    "zh:84212e750b3a319055ee0dc43ef40a1096fea6793af8d87aecc330ead4e8e9c9",
-    "zh:ac53b6cd95fc024b96dba46e204bbc4963e744c7017f11d454ba49a4a8355ee3",
-    "zh:cc6a4989874fc7a1d3b82f8be761867c85472b37c5656a81cee8385330a5afa2",
-    "zh:d1ffc766f855995b6117f7f40ec02e2404a8474630dbcc38b8355519af1a47f5",
-    "zh:e68183a7c0f1efec3e36931ca06d31060218a9d44379aad5269e9d6fc6e6f47f",
-    "zh:e7c0dbfae422f8ae663c3462d549ac69287038fc880bfad5c58790b82bfde620",
+    "h1:QbO4yjDrnoSpiYKSHrICNL1ZuWsl5J2rVRFj2kNg7xA=",
+    "zh:005a28a2c79f6b29680b0f57260c69c85d8a992688007b6e5645149bd379951f",
+    "zh:2604d825de72cf99b4899d7880837adeb19d371f48e419666e32c4c3cf6a72e9",
+    "zh:290da4eb18e44469480cf299bebce89f54e4d301f856cdffe2837b498878c7ec",
+    "zh:3e5ba1a55d38fa17533a18fc14a612e781ded76c6309734d3dc0a937be27eec1",
+    "zh:4a85de3cdb33c092d8ccfced3d7302934de0dd4f72bbcebd79d45afe0a0b6f85",
+    "zh:5fb1a79800833ae922aaba594a8b2bc83be1d254052e12e0ce8330ca0d8933d9",
+    "zh:679b9f50c6fe0476e74d37935f7598d46d6e9612f75b26a8ef1ca3c13144d06a",
+    "zh:893216e32378839668c51ef135af1676cd887d63e2edb6625cf9adad7bfa346f",
+    "zh:ad8f2fd19adbe4c10281ba9b3c8d5100877a9c541d3580bbbe9357714aa77619",
+    "zh:bff5d6fd15e98c12ee9ed98b0338761dc4a9ba671a37834926daeabf73c71783",
+    "zh:debdf15fbed8d63e397cd004bf65586bd2b93ce04e47ca51a7c70c1fe9168b87",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/google-beta" {
-  version = "4.0.0"
+  version = "4.6.0"
   hashes = [
-    "h1:OjAIZzqrDTErNuT9dcayeMMa0oy/n7I/IbveP4SudRE=",
-    "h1:peWoGRo4L85HpgmeeYl/Aj3CFL/mL590hOvyns6ZcP4=",
-    "zh:34ce5619a6bb8d34712c1c62926b150fa223e724a2645607f9d2fedd115e3479",
-    "zh:38ec64d8e1c49ebe53507c0706168d77adfe998a4a112dd4c2e79da435fd8d3d",
-    "zh:3a20431cd449342f84c69db91e9d68c9fba8fadec5e591257f717ccc4d98a29a",
-    "zh:7d92053e8fb15ac0ff92e6d9f4ccf3139d26a0ace23ec5477282a05365a21eb0",
-    "zh:860268215bd28c8d898a24176db8dd0cb95afc18da18b3df9d9faa3cb6b8e954",
-    "zh:893d093843a8434473404b540a1cb3929d70ad7908080d664db544d23f913cab",
-    "zh:9566a48125abea26b129999c05822852ed7e4bdc7cee37386101a9efb682f802",
-    "zh:b8d3af701b7a0070152fb318361171dd35e018f24699ce381f2e5358ff9819b7",
-    "zh:ce745343c9acfdcde5924cc1118fcbf85092a58c5bd9f0eb358a2a762f51b0b4",
-    "zh:e426b91d3b5101f27d74b06dc76f89d0a323f5ccbf40e7c48f993f75084e33dd",
-    "zh:f38d45989765d57a2b793e7a14748146a9859f41943a7015b07e0f9f9d9862d5",
+    "h1:dWs2rgFAeMsQAKUXsqq+xjPXSGjlmGqmHTKcTVr3p6o=",
+    "zh:689369bc111574c5bebb35e7bd4e00d5ca5c6482eeb4b406073c56d48dbd9a51",
+    "zh:6d478293641e265b6f6849e75c51da31b8ee8047ccb9b0f51a8ec77994b9488c",
+    "zh:71e1f4d76ffd3673a7a5158cf19bbb5407b590b10ca242cbebee3925f2257b7e",
+    "zh:7f48a5a3d056ba1b3f52365b65ae0c6c1fa7acf645c862844e8472cb53cd4c64",
+    "zh:86880c4f5c6a29c43e372d8c8c80b059f06d33f58f6f0de168c0a47fbbefc01a",
+    "zh:968a4d3080ff233de2f4bdfe9e8a8ceb029e19ded42a2d76e307ce94e9885aa6",
+    "zh:a243953d9df3bec2a32eed2ee5d011359525a86c28b71f02d542ec76a5adbd12",
+    "zh:ae1a407b960a752aba76405a36f83e584c34f096b1b91b09c053ad385e1d5887",
+    "zh:c96d9a829a832d64c9ed9cc507e6cb42673fe499aab4f9017be958e9ba0eaab3",
+    "zh:cf7bb0adde8822ed8a1ba86bb253af480fd792ac4ab9590a2ebdca90b55968dd",
+    "zh:ee0bdb27d679e97ee009b31e1a4a0275e6c0a5d7ac1435d3b511be8282ee5d89",
   ]
 }
 
@@ -43,7 +41,6 @@ provider "registry.terraform.io/hashicorp/null" {
   version = "3.1.0"
   hashes = [
     "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
-    "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
     "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
     "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
     "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",

--- a/terraform/envs/ci/main.tf
+++ b/terraform/envs/ci/main.tf
@@ -19,7 +19,7 @@ terraform {
     # Bucket is in project "lumberjack-dev-infra"
     # We can reuse this project for CI and sandbox envs with a different prefix.
     bucket = "lumberjack-dev-terraform"
-    prefix = "ci"
+    prefix = "github-ci"
   }
 }
 
@@ -52,7 +52,7 @@ variable "renew_random_tag" {
 module "e2e" {
   source        = "../../e2e"
   folder_parent = "folders/316290568068"
-  top_folder_id = "ci-e2e"
+  top_folder_id = "github-ci"
 
   // The billing account 'Gong Test'.
   billing_account = "016242-61A3FB-F92462"
@@ -67,9 +67,9 @@ module "e2e" {
 # project, this way, the IAM propagation delay for individual Cloud Run
 # instances during an integration run is aimed to be avoided.
 resource "google_project_iam_member" "audit_log_writer" {
-  project  = module.e2e.server_project
-  role     = "roles/run.invoker"
-  member   = "serviceAccount:${module.e2e.audit_log_writer}"
+  project = module.e2e.server_project
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${module.e2e.audit_log_writer}"
 }
 
 output "audit_log_server_url" {


### PR DESCRIPTION
The changes in https://github.com/abcxyz/lumberjack/pull/14 (intended to reenable integ tests) potentially caused unrecoverable problems. Here is my understanding:

1. In `integration_build.sh`, the script we run for each CI run, it always applies the CI env and try to get output from it (even though those outputs never change).
2. In https://github.com/abcxyz/lumberjack/pull/14, a change was made to the top level folder name, from `ci-e2e` to `github-ci-e2e`
3. When CI runs, `integration_build.sh` tried to reapply CI env with a different top folder name. This caused the existing env being torn down but **not cleanly** because it couldn't delete the bigquery dataset. As a result, it stuck in a weird state and integ test would not pass.

I tried to recover the old CI env by changing the top folder name back to `ci-e2e`. But it failed because folder names can't be reused. So we truly stuck in a weird state.

In this PR, I pretty much created a new CI env by 1) use a new GCS path for terraform state 2) a new top folder name `github-ci`.
I also hardcoded the necessary values in the `integration_build.sh` so CI run won't mess around the CI env. Thus, we can safely modify `integration_build.sh` to make integ test working on github.