### PR TITLE
test: don't use t.log/error in goroutines due to threadsafety issues

### DIFF
--- a/.github/workflows/github-presubmit-go.yml
+++ b/.github/workflows/github-presubmit-go.yml
@@ -34,6 +34,29 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           working-directory: clients/go
+      
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      
+      - name: gofmt
+        run: gofmt -s -d -l . 2>&1 | tee /dev/stderr | (! read)
+
+      - name: goimports
+        run: |
+          go install golang.org/x/tools/cmd/goimports@latest
+          goimports -l . 2>&1 | tee /dev/stderr | (! read)
+
+      - name: gomodtidy
+        run: |
+          for i in $(find . -name go.mod); do
+            pushd $(dirname $i)
+            go mod tidy
+            popd
+          done
+          git diff go.mod | tee /dev/stderr | (! read)
+          git diff go.sum | tee /dev/stderr | (! read)
 
   test:
     name: Tests

--- a/clients/go/apis/v1alpha1/audit_log_agent.pb.go
+++ b/clients/go/apis/v1alpha1/audit_log_agent.pb.go
@@ -9,10 +9,11 @@
 package v1alpha1
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/clients/go/apis/v1alpha1/audit_log_agent_grpc.pb.go
+++ b/clients/go/apis/v1alpha1/audit_log_agent_grpc.pb.go
@@ -4,6 +4,7 @@ package v1alpha1
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/clients/go/apis/v1alpha1/audit_log_request.pb.go
+++ b/clients/go/apis/v1alpha1/audit_log_request.pb.go
@@ -9,12 +9,13 @@
 package v1alpha1
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	audit "google.golang.org/genproto/googleapis/cloud/audit"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (


### PR DESCRIPTION
related to #47 