### PR TITLE
chore: remove workaround for previous versions of golang/mallocnanozone

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,10 +17,6 @@
 # Fail on any error.
 set -eEuo pipefail
 
-# Issue currently with Mac OS X 12.0.1 that requires setting MallocNanoZone
-# b/206135512
-export MallocNanoZone=0
-
 # Run all Go tests.
 # Go test only works from a Go module.
 (cd clients/go && go test -shuffle=on -count=1 -race -timeout=10m -coverprofile=coverage.out ./...)


### PR DESCRIPTION
A memory corruption issue existed in golang 1.16, 1.17. The team has since resolved this. Installing latest versions no longer requires this workaround. Verified with 1.17.6