### PR TITLE
fix: fix typo in runtime.go error text

### DIFF
--- a/clients/go/pkg/audit/runtime.go
+++ b/clients/go/pkg/audit/runtime.go
@@ -255,7 +255,7 @@ func toStructVal(monitoredResource *mrpb.MonitoredResource) (*structpb.Value, er
 	}
 	s := &structpb.Struct{}
 	if err := protojson.Unmarshal(b, s); err != nil {
-		return nil, fmt.Errorf("unmarshall error: %w", err)
+		return nil, fmt.Errorf("unmarshal error: %w", err)
 	}
 	val := &structpb.Value{
 		Kind: &structpb.Value_StructValue{StructValue: s},


### PR DESCRIPTION
Noticed this while looking at a submitted change from yesterday. Nothing quite like a 1 char pr :)