### PR TITLE
fix: Have Go ignore method name leading slashes in audit rule selector

### DIFF
--- a/clients/go/pkg/audit/rules.go
+++ b/clients/go/pkg/audit/rules.go
@@ -53,6 +53,9 @@ func isRuleApplicable(rule *alpb.AuditRule, methodName string) bool {
 	if sel == wildcard {
 		return true
 	}
+	// Ignore any leading slashes when check rules.
+	sel = strings.TrimLeft(sel, "/")
+	methodName = strings.TrimLeft(methodName, "/")
 	if strings.HasSuffix(sel, wildcard) {
 		return strings.HasPrefix(methodName, sel[:len(sel)-1])
 	}

--- a/clients/go/pkg/audit/rules_test.go
+++ b/clients/go/pkg/audit/rules_test.go
@@ -24,12 +24,14 @@ func TestMostRelevantRule(t *testing.T) {
 	t.Parallel()
 
 	ruleBySelector := map[string]*alpb.AuditRule{
-		"a.b.c": {Selector: "a.b.c"},
-		"a.b.*": {Selector: "a.b.*"},
-		"a.*":   {Selector: "a.*"},
-		"*":     {Selector: "*"},
-		"a.b.d": {Selector: "a.b.d"},
-		"foo*":  {Selector: "foo*"},
+		"a.b.c":   {Selector: "a.b.c"},
+		"a.b.*":   {Selector: "a.b.*"},
+		"a.*":     {Selector: "a.*"},
+		"*":       {Selector: "*"},
+		"a.b.d":   {Selector: "a.b.d"},
+		"foo*":    {Selector: "foo*"},
+		"//a.b.c": {Selector: "//a.b.c"},
+		"/a.b.*":  {Selector: "/a.b.*"},
 	}
 
 	tests := []struct {
@@ -94,6 +96,16 @@ func TestMostRelevantRule(t *testing.T) {
 				ruleBySelector["a.*"],
 			},
 			methodName: "d.e.f",
+		},
+		{
+			name: "match_ignore_leading_slashes",
+			rules: []*alpb.AuditRule{
+				ruleBySelector["//a.b.c"],
+				ruleBySelector["/a.b.*"],
+				ruleBySelector["a.*"],
+			},
+			methodName: "//a.b.z",
+			wantRule:   ruleBySelector["/a.b.*"],
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Fix: https://github.com/abcxyz/lumberjack/issues/169