### PR TITLE
chore: Bump Jackson Databind to version 2.13.2.2.

### DIFF
--- a/clients/java-logger/grpc-test-app/pom.xml
+++ b/clients/java-logger/grpc-test-app/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.5</version>
+      <version>2.13.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/clients/java-logger/library/pom.xml
+++ b/clients/java-logger/library/pom.xml
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.6.1</version>
+      <version>2.13.2.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.8.3</version>
+      <version>2.13.2</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Per https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind, 2.13.2.2 does not have any listed vulnerabilities.