### PR TITLE
refactor: remove builder pattern from go code

### DIFF
--- a/clients/go/pkg/audit/client_test.go
+++ b/clients/go/pkg/audit/client_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/errutil"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
 )
@@ -35,7 +35,7 @@ type testOrderProcessor struct {
 	returnErr error
 }
 
-func (p testOrderProcessor) Process(_ context.Context, logReq *alpb.AuditLogRequest) error {
+func (p testOrderProcessor) Process(_ context.Context, logReq *api.AuditLogRequest) error {
 	if logReq.Labels == nil {
 		logReq.Labels = map[string]string{}
 	}
@@ -49,40 +49,40 @@ func TestLog(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		name          string
-		logReq        *alpb.AuditLogRequest
+		logReq        *api.AuditLogRequest
 		opts          []Option
-		wantLogReq    *alpb.AuditLogRequest
+		wantLogReq    *api.AuditLogRequest
 		wantErrSubstr string
 	}{
 		{
 			name:       "well_formed_log_should_succeed_with_default_options",
-			logReq:     testutil.ReqBuilder().Build(),
-			wantLogReq: testutil.ReqBuilder().Build(),
+			logReq:     testutil.NewRequest(),
+			wantLogReq: testutil.NewRequest(),
 		},
 		{
 			name:   "nil_payload_should_error_from_default_validator_fail_close",
-			logReq: &alpb.AuditLogRequest{},
+			logReq: &api.AuditLogRequest{},
 			opts: []Option{
-				WithLogMode(alpb.AuditLogRequest_FAIL_CLOSE),
+				WithLogMode(api.AuditLogRequest_FAIL_CLOSE),
 			},
-			wantLogReq:    &alpb.AuditLogRequest{Mode: alpb.AuditLogRequest_FAIL_CLOSE},
+			wantLogReq:    &api.AuditLogRequest{Mode: api.AuditLogRequest_FAIL_CLOSE},
 			wantErrSubstr: "failed to execute validator",
 		},
 		{
 			name:   "should_run_validator_then_mutator_then_backend",
-			logReq: testutil.ReqBuilder().Build(),
+			logReq: testutil.NewRequest(),
 			opts: []Option{
 				WithBackend(testOrderProcessor{name: "backend"}),
 				WithMutator(testOrderProcessor{name: "mutator"}),
 				WithValidator(testOrderProcessor{name: "validator"}),
 			},
-			wantLogReq: testutil.ReqBuilder().WithLabels(
+			wantLogReq: testutil.NewRequest(testutil.WithLabels(
 				map[string]string{processorOrderKey: "validator, mutator, backend, "},
-			).Build(),
+			)),
 		},
 		{
 			name:   "multiple_ordered_validators_should_run_before_multiple_ordered_backends",
-			logReq: testutil.ReqBuilder().Build(),
+			logReq: testutil.NewRequest(),
 			opts: []Option{
 				WithBackend(testOrderProcessor{name: "backend0"}),
 				WithValidator(testOrderProcessor{name: "validator0"}),
@@ -90,79 +90,81 @@ func TestLog(t *testing.T) {
 				WithBackend(testOrderProcessor{name: "backend1"}),
 				WithValidator(testOrderProcessor{name: "validator2"}),
 			},
-			wantLogReq: testutil.ReqBuilder().WithLabels(
+			wantLogReq: testutil.NewRequest(testutil.WithLabels(
 				map[string]string{processorOrderKey: "validator0, validator1, validator2, backend0, backend1, "},
-			).Build(),
+			)),
 		},
 		{
 			name:   "skip_subsequent_processors_when_precondition_failed",
-			logReq: testutil.ReqBuilder().Build(),
+			logReq: testutil.NewRequest(),
 			opts: []Option{
 				WithValidator(testOrderProcessor{name: "validator0"}),
 				WithValidator(testOrderProcessor{name: "validator1", returnErr: fmt.Errorf("skip: %w", ErrFailedPrecondition)}),
 				WithBackend(testOrderProcessor{name: "backend0"}),
 				WithBackend(testOrderProcessor{name: "backend1"}),
 			},
-			wantLogReq: testutil.ReqBuilder().WithLabels(
+			wantLogReq: testutil.NewRequest(testutil.WithLabels(
 				map[string]string{processorOrderKey: "validator0, validator1, "},
-			).Build(),
+			)),
 		},
 		{
 			name:   "injected_error_in_mutator_should_return_error_on_fail_close",
-			logReq: testutil.ReqBuilder().Build(),
+			logReq: testutil.NewRequest(),
 			opts: []Option{
 				WithMutator(testOrderProcessor{name: "fake", returnErr: fmt.Errorf("fake error")}),
-				WithLogMode(alpb.AuditLogRequest_FAIL_CLOSE),
+				WithLogMode(api.AuditLogRequest_FAIL_CLOSE),
 			},
-			wantLogReq: testutil.ReqBuilder().WithLabels(
-				map[string]string{processorOrderKey: "fake, "},
-			).WithMode(alpb.AuditLogRequest_FAIL_CLOSE).Build(),
+			wantLogReq: testutil.NewRequest(
+				testutil.WithLabels(
+					map[string]string{processorOrderKey: "fake, "},
+				),
+				testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
 			wantErrSubstr: "failed to execute mutator",
 		},
 		{
 			name:   "injected_error_in_mutator_should_return_nil_on_best_effort",
-			logReq: testutil.ReqBuilder().Build(),
+			logReq: testutil.NewRequest(),
 			opts: []Option{
 				WithMutator(testOrderProcessor{name: "fake", returnErr: fmt.Errorf("fake error")}),
-				WithLogMode(alpb.AuditLogRequest_BEST_EFFORT),
+				WithLogMode(api.AuditLogRequest_BEST_EFFORT),
 			},
-			wantLogReq: testutil.ReqBuilder().WithLabels(
-				map[string]string{processorOrderKey: "fake, "},
-			).WithMode(alpb.AuditLogRequest_BEST_EFFORT).Build(),
+			wantLogReq: testutil.NewRequest(
+				testutil.WithLabels(map[string]string{processorOrderKey: "fake, "}),
+				testutil.WithMode(api.AuditLogRequest_BEST_EFFORT)),
 		},
 		{
 			name:   "failed_precondition_in_mutator_should_return_nil_on_best_effort",
-			logReq: testutil.ReqBuilder().Build(),
+			logReq: testutil.NewRequest(),
 			opts: []Option{
 				WithMutator(testOrderProcessor{name: "fake", returnErr: fmt.Errorf("fake error: %w", ErrFailedPrecondition)}),
-				WithLogMode(alpb.AuditLogRequest_BEST_EFFORT),
+				WithLogMode(api.AuditLogRequest_BEST_EFFORT),
 			},
-			wantLogReq: testutil.ReqBuilder().WithLabels(
-				map[string]string{processorOrderKey: "fake, "},
-			).WithMode(alpb.AuditLogRequest_BEST_EFFORT).Build(),
+			wantLogReq: testutil.NewRequest(
+				testutil.WithLabels(map[string]string{processorOrderKey: "fake, "}),
+				testutil.WithMode(api.AuditLogRequest_BEST_EFFORT)),
 		},
 		{
 			name:   "injected_error_in_backend_should_return_error_on_fail_close",
-			logReq: testutil.ReqBuilder().Build(),
+			logReq: testutil.NewRequest(),
 			opts: []Option{
 				WithBackend(testOrderProcessor{name: "fake", returnErr: fmt.Errorf("fake error")}),
-				WithLogMode(alpb.AuditLogRequest_FAIL_CLOSE),
+				WithLogMode(api.AuditLogRequest_FAIL_CLOSE),
 			},
-			wantLogReq: testutil.ReqBuilder().WithLabels(
-				map[string]string{processorOrderKey: "fake, "},
-			).WithMode(alpb.AuditLogRequest_FAIL_CLOSE).Build(),
+			wantLogReq: testutil.NewRequest(
+				testutil.WithLabels(map[string]string{processorOrderKey: "fake, "}),
+				testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
 			wantErrSubstr: "failed to execute backend",
 		},
 		{
 			name:   "failed_precondition_in_backend_should_return_error_on_fail_close",
-			logReq: testutil.ReqBuilder().Build(),
+			logReq: testutil.NewRequest(),
 			opts: []Option{
 				WithBackend(testOrderProcessor{name: "fake", returnErr: fmt.Errorf("fake error: %w", ErrFailedPrecondition)}),
-				WithLogMode(alpb.AuditLogRequest_FAIL_CLOSE),
+				WithLogMode(api.AuditLogRequest_FAIL_CLOSE),
 			},
-			wantLogReq: testutil.ReqBuilder().WithLabels(
-				map[string]string{processorOrderKey: "fake, "},
-			).WithMode(alpb.AuditLogRequest_FAIL_CLOSE).Build(),
+			wantLogReq: testutil.NewRequest(
+				testutil.WithLabels(map[string]string{processorOrderKey: "fake, "}),
+				testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
 			wantErrSubstr: "failed to execute backend",
 		},
 	}
@@ -198,25 +200,25 @@ func TestHandleReturn_Client(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		logMode alpb.AuditLogRequest_LogMode
+		logMode api.AuditLogRequest_LogMode
 		err     error
 		wantErr bool
 	}{
 		{
 			name:    "returns_nil_with_err_best_effort",
-			logMode: alpb.AuditLogRequest_BEST_EFFORT,
+			logMode: api.AuditLogRequest_BEST_EFFORT,
 			err:     errors.New("test error"),
 			wantErr: false,
 		},
 		{
 			name:    "returns_err_with_err_fail_close",
-			logMode: alpb.AuditLogRequest_FAIL_CLOSE,
+			logMode: api.AuditLogRequest_FAIL_CLOSE,
 			err:     errors.New("test error"),
 			wantErr: true,
 		},
 		{
 			name:    "returns_nil_no_err",
-			logMode: alpb.AuditLogRequest_FAIL_CLOSE,
+			logMode: api.AuditLogRequest_FAIL_CLOSE,
 			wantErr: false,
 		},
 	}

--- a/clients/go/pkg/audit/labels.go
+++ b/clients/go/pkg/audit/labels.go
@@ -17,7 +17,7 @@ package audit
 import (
 	"context"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 )
 
 // LabelProcessor is a mutator that adds labels to each AuditLogRequest. These labels
@@ -30,7 +30,7 @@ type LabelProcessor struct {
 
 // Process adds the configured labels to each passed in request, without overwriting
 // existing labels.
-func (p *LabelProcessor) Process(ctx context.Context, logReq *alpb.AuditLogRequest) error {
+func (p *LabelProcessor) Process(ctx context.Context, logReq *api.AuditLogRequest) error {
 	if len(p.DefaultLabels) == 0 {
 		// short circuit if there are no labels to add
 		return nil

--- a/clients/go/pkg/audit/labels_test.go
+++ b/clients/go/pkg/audit/labels_test.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"testing"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -32,26 +32,26 @@ func TestProcessLabels(t *testing.T) {
 	tests := []struct {
 		name         string
 		configLabels map[string]string
-		logReq       *alpb.AuditLogRequest
-		wantLogReq   *alpb.AuditLogRequest
+		logReq       *api.AuditLogRequest
+		wantLogReq   *api.AuditLogRequest
 		wantErr      error
 	}{
 		{
 			name:         "adds_labels",
 			configLabels: map[string]string{"label1": "value1"},
-			logReq:       testutil.ReqBuilder().Build(),
-			wantLogReq:   testutil.ReqBuilder().WithLabels(map[string]string{"label1": "value1"}).Build(),
+			logReq:       testutil.NewRequest(),
+			wantLogReq:   testutil.NewRequest(testutil.WithLabels(map[string]string{"label1": "value1"})),
 		},
 		{
 			name:         "adds_labels_without_overwriting",
 			configLabels: map[string]string{"label1": "value1", "label2": "value2"},
-			logReq:       testutil.ReqBuilder().WithLabels(map[string]string{"label1": "requestval"}).Build(),
-			wantLogReq:   testutil.ReqBuilder().WithLabels(map[string]string{"label1": "requestval", "label2": "value2"}).Build(),
+			logReq:       testutil.NewRequest(testutil.WithLabels(map[string]string{"label1": "requestval"})),
+			wantLogReq:   testutil.NewRequest(testutil.WithLabels(map[string]string{"label1": "requestval", "label2": "value2"})),
 		},
 		{
 			name:       "adds_nothing_if_nil_labels",
-			logReq:     testutil.ReqBuilder().WithLabels(map[string]string{"label1": "requestval"}).Build(),
-			wantLogReq: testutil.ReqBuilder().WithLabels(map[string]string{"label1": "requestval"}).Build(),
+			logReq:     testutil.NewRequest(testutil.WithLabels(map[string]string{"label1": "requestval"})),
+			wantLogReq: testutil.NewRequest(testutil.WithLabels(map[string]string{"label1": "requestval"})),
 		},
 	}
 	for _, tc := range tests {

--- a/clients/go/pkg/audit/rules.go
+++ b/clients/go/pkg/audit/rules.go
@@ -17,7 +17,7 @@ package audit
 import (
 	"strings"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 )
 
 const wildcard = "*"
@@ -29,9 +29,9 @@ const wildcard = "*"
 //
 // If none of the Rules are relevant to the given method (i.e. the
 // the selectors don't match), we return nil.
-func mostRelevantRule(methodName string, rules []*alpb.AuditRule) *alpb.AuditRule {
+func mostRelevantRule(methodName string, rules []*api.AuditRule) *api.AuditRule {
 	var longest int
-	var mostRelevant *alpb.AuditRule
+	var mostRelevant *api.AuditRule
 	for _, r := range rules {
 		if isRuleApplicable(r, methodName) && len(r.Selector) > longest {
 			longest = len(r.Selector)
@@ -48,7 +48,7 @@ func mostRelevantRule(methodName string, rules []*alpb.AuditRule) *alpb.AuditRul
 // isRuleApplicable determines if a Rule applies to
 // the given method by comparing the Rule's Selector
 // to the methodName.
-func isRuleApplicable(rule *alpb.AuditRule, methodName string) bool {
+func isRuleApplicable(rule *api.AuditRule, methodName string) bool {
 	sel := rule.Selector
 	if sel == wildcard {
 		return true

--- a/clients/go/pkg/audit/rules_test.go
+++ b/clients/go/pkg/audit/rules_test.go
@@ -17,13 +17,13 @@ package audit
 import (
 	"testing"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 )
 
 func TestMostRelevantRule(t *testing.T) {
 	t.Parallel()
 
-	ruleBySelector := map[string]*alpb.AuditRule{
+	ruleBySelector := map[string]*api.AuditRule{
 		"a.b.c":   {Selector: "a.b.c"},
 		"a.b.*":   {Selector: "a.b.*"},
 		"a.*":     {Selector: "a.*"},
@@ -36,13 +36,13 @@ func TestMostRelevantRule(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		rules      []*alpb.AuditRule
+		rules      []*api.AuditRule
 		methodName string
-		wantRule   *alpb.AuditRule
+		wantRule   *api.AuditRule
 	}{
 		{
 			name: "exact_match_wins",
-			rules: []*alpb.AuditRule{
+			rules: []*api.AuditRule{
 				ruleBySelector["a.b.c"],
 				ruleBySelector["a.b.*"],
 				ruleBySelector["*"],
@@ -52,7 +52,7 @@ func TestMostRelevantRule(t *testing.T) {
 		},
 		{
 			name: "partial_wildcard_match_wins",
-			rules: []*alpb.AuditRule{
+			rules: []*api.AuditRule{
 				ruleBySelector["a.b.c"],
 				ruleBySelector["a.b.*"],
 				ruleBySelector["*"],
@@ -62,7 +62,7 @@ func TestMostRelevantRule(t *testing.T) {
 		},
 		{
 			name: "partial_wildcard_match_wins_again",
-			rules: []*alpb.AuditRule{
+			rules: []*api.AuditRule{
 				ruleBySelector["*"],
 				ruleBySelector["a.b.*"],
 				ruleBySelector["a.b.c"],
@@ -72,7 +72,7 @@ func TestMostRelevantRule(t *testing.T) {
 		},
 		{
 			name: "wildcard_match_wins",
-			rules: []*alpb.AuditRule{
+			rules: []*api.AuditRule{
 				ruleBySelector["a.b.c"],
 				ruleBySelector["a.b.*"],
 				ruleBySelector["*"],
@@ -82,7 +82,7 @@ func TestMostRelevantRule(t *testing.T) {
 		},
 		{
 			name: "wildcard_suffix_barley_matches",
-			rules: []*alpb.AuditRule{
+			rules: []*api.AuditRule{
 				ruleBySelector["foo*"],
 			},
 			methodName: "foo",
@@ -90,7 +90,7 @@ func TestMostRelevantRule(t *testing.T) {
 		},
 		{
 			name: "no_match",
-			rules: []*alpb.AuditRule{
+			rules: []*api.AuditRule{
 				ruleBySelector["a.b.c"],
 				ruleBySelector["a.b.*"],
 				ruleBySelector["a.*"],
@@ -99,7 +99,7 @@ func TestMostRelevantRule(t *testing.T) {
 		},
 		{
 			name: "match_ignore_leading_slashes",
-			rules: []*alpb.AuditRule{
+			rules: []*api.AuditRule{
 				ruleBySelector["//a.b.c"],
 				ruleBySelector["/a.b.*"],
 				ruleBySelector["a.*"],

--- a/clients/go/pkg/audit/runtime.go
+++ b/clients/go/pkg/audit/runtime.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -266,7 +266,7 @@ func toStructVal(monitoredResource *mrpb.MonitoredResource) (*structpb.Value, er
 // Process stores the application's GCP runtime information in the audit log
 // request. More specifically, in the Payload.Metadata under the key
 // "originating_resource".
-func (p *runtimeInfo) Process(ctx context.Context, logReq *alpb.AuditLogRequest) error {
+func (p *runtimeInfo) Process(ctx context.Context, logReq *api.AuditLogRequest) error {
 	if p == nil || p.monitoredResource == nil {
 		return nil
 	}

--- a/clients/go/pkg/audit/runtime_test.go
+++ b/clients/go/pkg/audit/runtime_test.go
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
 )
 
@@ -32,8 +32,8 @@ func TestRuntimeInfo_Process(t *testing.T) {
 	tests := []struct {
 		name       string
 		r          *runtimeInfo
-		logReq     *alpb.AuditLogRequest
-		wantLogReq *alpb.AuditLogRequest
+		logReq     *api.AuditLogRequest
+		wantLogReq *api.AuditLogRequest
 	}{
 		{
 			name: "should_write_monitored_resource_to_payload_metadata",
@@ -50,8 +50,8 @@ func TestRuntimeInfo_Process(t *testing.T) {
 					},
 				}),
 			},
-			logReq: testutil.ReqBuilder().Build(),
-			wantLogReq: testutil.ReqBuilder().WithMetadata(&structpb.Struct{
+			logReq: testutil.NewRequest(),
+			wantLogReq: testutil.NewRequest(testutil.WithMetadata(&structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"originating_resource": structpb.NewStructValue(&structpb.Struct{
 						Fields: map[string]*structpb.Value{
@@ -65,7 +65,7 @@ func TestRuntimeInfo_Process(t *testing.T) {
 						},
 					}),
 				},
-			}).Build(),
+			})),
 		},
 		{
 			name: "should_append_monitored_resources_to_payload_metadata",
@@ -82,7 +82,7 @@ func TestRuntimeInfo_Process(t *testing.T) {
 					},
 				}),
 			},
-			logReq: testutil.ReqBuilder().WithMetadata(&structpb.Struct{
+			logReq: testutil.NewRequest(testutil.WithMetadata(&structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"existing_key": structpb.NewStructValue(&structpb.Struct{
 						Fields: map[string]*structpb.Value{
@@ -90,8 +90,8 @@ func TestRuntimeInfo_Process(t *testing.T) {
 						},
 					}),
 				},
-			}).Build(),
-			wantLogReq: testutil.ReqBuilder().WithMetadata(&structpb.Struct{
+			})),
+			wantLogReq: testutil.NewRequest(testutil.WithMetadata(&structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"existing_key": structpb.NewStructValue(&structpb.Struct{
 						Fields: map[string]*structpb.Value{
@@ -110,11 +110,11 @@ func TestRuntimeInfo_Process(t *testing.T) {
 						},
 					}),
 				},
-			}).Build(),
+			})),
 		},
 		{
 			name: "nil_runtimeinfo_should_leave_metadata_untouched",
-			logReq: testutil.ReqBuilder().WithMetadata(&structpb.Struct{
+			logReq: testutil.NewRequest(testutil.WithMetadata(&structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"existing_key": structpb.NewStructValue(&structpb.Struct{
 						Fields: map[string]*structpb.Value{
@@ -122,8 +122,8 @@ func TestRuntimeInfo_Process(t *testing.T) {
 						},
 					}),
 				},
-			}).Build(),
-			wantLogReq: testutil.ReqBuilder().WithMetadata(&structpb.Struct{
+			})),
+			wantLogReq: testutil.NewRequest(testutil.WithMetadata(&structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"existing_key": structpb.NewStructValue(&structpb.Struct{
 						Fields: map[string]*structpb.Value{
@@ -131,12 +131,12 @@ func TestRuntimeInfo_Process(t *testing.T) {
 						},
 					}),
 				},
-			}).Build(),
+			})),
 		},
 		{
 			name: "nil_monitored_resource_should_leave_metadata_untouched",
 			r:    &runtimeInfo{},
-			logReq: testutil.ReqBuilder().WithMetadata(&structpb.Struct{
+			logReq: testutil.NewRequest(testutil.WithMetadata(&structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"existing_key": structpb.NewStructValue(&structpb.Struct{
 						Fields: map[string]*structpb.Value{
@@ -144,8 +144,8 @@ func TestRuntimeInfo_Process(t *testing.T) {
 						},
 					}),
 				},
-			}).Build(),
-			wantLogReq: testutil.ReqBuilder().WithMetadata(&structpb.Struct{
+			})),
+			wantLogReq: testutil.NewRequest(testutil.WithMetadata(&structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"existing_key": structpb.NewStructValue(&structpb.Struct{
 						Fields: map[string]*structpb.Value{
@@ -153,7 +153,7 @@ func TestRuntimeInfo_Process(t *testing.T) {
 						},
 					}),
 				},
-			}).Build(),
+			})),
 		},
 	}
 	for _, tc := range tests {

--- a/clients/go/pkg/audit/validation.go
+++ b/clients/go/pkg/audit/validation.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 	"strings"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 )
 
 type requestValidation struct{}
 
 // Process with receiver auditLogRequestValidation verifies
 // that the AuditLogRequest is properly formed.
-func (p requestValidation) Process(_ context.Context, logReq *alpb.AuditLogRequest) error {
+func (p requestValidation) Process(_ context.Context, logReq *api.AuditLogRequest) error {
 	if logReq == nil {
 		return fmt.Errorf("request shouldn't be nil: %w", ErrInvalidRequest)
 	}

--- a/clients/go/pkg/audit/validation_test.go
+++ b/clients/go/pkg/audit/validation_test.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/genproto/googleapis/cloud/audit"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
 )
 
@@ -33,19 +33,19 @@ func TestRequestValidation_Process(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		name       string
-		logReq     *alpb.AuditLogRequest
-		wantLogReq *alpb.AuditLogRequest
+		logReq     *api.AuditLogRequest
+		wantLogReq *api.AuditLogRequest
 		wantErr    error
 	}{
 		{
 			name:       "valid_AuditLogRequest",
-			logReq:     testutil.ReqBuilder().Build(),
-			wantLogReq: testutil.ReqBuilder().Build(),
+			logReq:     testutil.NewRequest(),
+			wantLogReq: testutil.NewRequest(),
 		},
 		{
 			name:       "should_error_when_logReq_payload_is_nil",
-			logReq:     &alpb.AuditLogRequest{},
-			wantLogReq: &alpb.AuditLogRequest{},
+			logReq:     &api.AuditLogRequest{},
+			wantLogReq: &api.AuditLogRequest{},
 			wantErr:    ErrInvalidRequest,
 		},
 		{
@@ -54,12 +54,12 @@ func TestRequestValidation_Process(t *testing.T) {
 		},
 		{
 			name: "should_error_when_authInfo_is_nil",
-			logReq: &alpb.AuditLogRequest{
+			logReq: &api.AuditLogRequest{
 				Payload: &audit.AuditLog{
 					ServiceName: "test-service",
 				},
 			},
-			wantLogReq: &alpb.AuditLogRequest{
+			wantLogReq: &api.AuditLogRequest{
 				Payload: &audit.AuditLog{
 					ServiceName: "test-service",
 				},
@@ -68,13 +68,13 @@ func TestRequestValidation_Process(t *testing.T) {
 		},
 		{
 			name: "should_error_when_auth_email_is_nil",
-			logReq: &alpb.AuditLogRequest{
+			logReq: &api.AuditLogRequest{
 				Payload: &audit.AuditLog{
 					ServiceName:        "test-service",
 					AuthenticationInfo: &audit.AuthenticationInfo{},
 				},
 			},
-			wantLogReq: &alpb.AuditLogRequest{
+			wantLogReq: &api.AuditLogRequest{
 				Payload: &audit.AuditLog{
 					ServiceName:        "test-service",
 					AuthenticationInfo: &audit.AuthenticationInfo{},
@@ -84,7 +84,7 @@ func TestRequestValidation_Process(t *testing.T) {
 		},
 		{
 			name: "should_error_when_auth_email_has_no_domain",
-			logReq: &alpb.AuditLogRequest{
+			logReq: &api.AuditLogRequest{
 				Payload: &audit.AuditLog{
 					ServiceName: "test-service",
 					AuthenticationInfo: &audit.AuthenticationInfo{
@@ -92,7 +92,7 @@ func TestRequestValidation_Process(t *testing.T) {
 					},
 				},
 			},
-			wantLogReq: &alpb.AuditLogRequest{
+			wantLogReq: &api.AuditLogRequest{
 				Payload: &audit.AuditLog{
 					ServiceName: "test-service",
 					AuthenticationInfo: &audit.AuthenticationInfo{
@@ -104,7 +104,7 @@ func TestRequestValidation_Process(t *testing.T) {
 		},
 		{
 			name: "should_error_when_serviceName_is_empty",
-			logReq: &alpb.AuditLogRequest{
+			logReq: &api.AuditLogRequest{
 				Payload: &audit.AuditLog{
 					ServiceName: "",
 					AuthenticationInfo: &audit.AuthenticationInfo{
@@ -112,7 +112,7 @@ func TestRequestValidation_Process(t *testing.T) {
 					},
 				},
 			},
-			wantLogReq: &alpb.AuditLogRequest{
+			wantLogReq: &api.AuditLogRequest{
 				Payload: &audit.AuditLog{
 					ServiceName: "",
 					AuthenticationInfo: &audit.AuthenticationInfo{

--- a/clients/go/pkg/auditopt/config.go
+++ b/clients/go/pkg/auditopt/config.go
@@ -38,7 +38,7 @@ import (
 	"github.com/sethvargo/go-envconfig"
 	"gopkg.in/yaml.v2"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 )
 
 const DefaultConfigFilePath = "/etc/auditlogging/config.yaml"
@@ -158,7 +158,7 @@ func interceptorFromConfigFile(path string, lookuper envconfig.Lookuper) audit.I
 	}
 }
 
-func clientFromConfig(c *audit.Client, cfg *alpb.Config) error {
+func clientFromConfig(c *audit.Client, cfg *api.Config) error {
 	opts := []audit.Option{audit.WithRuntimeInfo()}
 
 	withPrincipalFilter, err := principalFilterFromConfig(cfg)
@@ -186,7 +186,7 @@ func clientFromConfig(c *audit.Client, cfg *alpb.Config) error {
 	return nil
 }
 
-func principalFilterFromConfig(cfg *alpb.Config) (audit.Option, error) {
+func principalFilterFromConfig(cfg *api.Config) (audit.Option, error) {
 	if cfg.Condition == nil || cfg.Condition.Regex == nil {
 		return nil, nil
 	}
@@ -203,7 +203,7 @@ func principalFilterFromConfig(cfg *alpb.Config) (audit.Option, error) {
 	return audit.WithValidator(m), nil
 }
 
-func backendsFromConfig(cfg *alpb.Config) ([]audit.Option, error) {
+func backendsFromConfig(cfg *api.Config) ([]audit.Option, error) {
 	var backendOpts []audit.Option
 
 	if cfg.Backend.Remote != nil {
@@ -226,7 +226,7 @@ func backendsFromConfig(cfg *alpb.Config) ([]audit.Option, error) {
 
 	if cfg.Backend.CloudLogging != nil {
 		var opts []cloudlogging.Option
-		if cfg.GetLogMode() == alpb.AuditLogRequest_BEST_EFFORT {
+		if cfg.GetLogMode() == api.AuditLogRequest_BEST_EFFORT {
 			opts = append(opts, cloudlogging.WithDefaultBestEffort())
 		}
 
@@ -253,13 +253,13 @@ func backendsFromConfig(cfg *alpb.Config) ([]audit.Option, error) {
 	return backendOpts, nil
 }
 
-func labelsFromConfig(cfg *alpb.Config) audit.Option {
+func labelsFromConfig(cfg *api.Config) audit.Option {
 	lp := audit.LabelProcessor{DefaultLabels: cfg.Labels}
 	return audit.WithMutator(&lp)
 }
 
-func loadConfig(b []byte, lookuper envconfig.Lookuper) (*alpb.Config, error) {
-	cfg := &alpb.Config{}
+func loadConfig(b []byte, lookuper envconfig.Lookuper) (*api.Config, error) {
+	cfg := &api.Config{}
 	if err := yaml.Unmarshal(b, cfg); err != nil {
 		return nil, err
 	}

--- a/clients/go/pkg/auditopt/config_test.go
+++ b/clients/go/pkg/auditopt/config_test.go
@@ -25,24 +25,24 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sethvargo/go-envconfig"
-	calpb "google.golang.org/genproto/googleapis/cloud/audit"
+	capi "google.golang.org/genproto/googleapis/cloud/audit"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/audit"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/errutil"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
 )
 
 type fakeServer struct {
-	alpb.UnimplementedAuditLogAgentServer
-	gotReq *alpb.AuditLogRequest
+	api.UnimplementedAuditLogAgentServer
+	gotReq *api.AuditLogRequest
 }
 
-func (s *fakeServer) ProcessLog(_ context.Context, logReq *alpb.AuditLogRequest) (*alpb.AuditLogResponse, error) {
+func (s *fakeServer) ProcessLog(_ context.Context, logReq *api.AuditLogRequest) (*api.AuditLogResponse, error) {
 	s.gotReq = logReq
-	return &alpb.AuditLogResponse{Result: logReq}, nil
+	return &api.AuditLogResponse{Result: logReq}, nil
 }
 
 func TestMustFromConfigFile(t *testing.T) {
@@ -52,8 +52,8 @@ func TestMustFromConfigFile(t *testing.T) {
 		name          string
 		envs          map[string]string
 		fileContent   string
-		req           *alpb.AuditLogRequest
-		wantReq       *alpb.AuditLogRequest
+		req           *api.AuditLogRequest
+		wantReq       *api.AuditLogRequest
 		wantErrSubstr string
 	}{
 		{
@@ -71,8 +71,8 @@ backend:
     address: %s
     insecure_enabled: true
 `,
-			req:     testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
-			wantReq: testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
+			req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
 		},
 		{
 			name: "condition_not_set_log_all",
@@ -86,8 +86,8 @@ backend:
     address: %s
     insecure_enabled: true
 `,
-			req:     testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
-			wantReq: testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
+			req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
 		},
 		{
 			name: "env_var_overwrites_config_file",
@@ -107,8 +107,8 @@ security_context:
   from_raw_jwt:
   - key: authorization
 `,
-			req:     testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
-			wantReq: testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
+			req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
 		},
 		{
 			name: "explicitly_include_service_account",
@@ -126,8 +126,8 @@ security_context:
   from_raw_jwt:
   - key: authorization
 `,
-			req:     testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
-			wantReq: testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
+			req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
 		},
 		{
 			name: "empty_string_allowed_for_regex_filter",
@@ -145,7 +145,7 @@ security_context:
   from_raw_jwt:
   - key: authorization
 `,
-			req: testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
+			req: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
 		},
 		{
 			name:          "invalid_config_file_should_error",
@@ -195,7 +195,7 @@ security_context:
 			r := &fakeServer{}
 
 			addr, _ := testutil.TestFakeGRPCServer(t, func(s *grpc.Server) {
-				alpb.RegisterAuditLogAgentServer(s, r)
+				api.RegisterAuditLogAgentServer(s, r)
 			})
 
 			path := filepath.Join(t.TempDir(), "config.yaml")
@@ -220,7 +220,7 @@ security_context:
 				// We ignore `AuditLog.Metadata` because it contains the
 				// runtime information which varies depending on the
 				// environment executing the unit test.
-				protocmp.IgnoreFields(&calpb.AuditLog{}, "metadata"),
+				protocmp.IgnoreFields(&capi.AuditLog{}, "metadata"),
 			}
 			if diff := cmp.Diff(tc.wantReq, r.gotReq, cmpopts...); diff != "" {
 				t.Errorf("audit logging backend got request (-want,+got):\n%s", diff)
@@ -264,15 +264,15 @@ backend:
 		name          string
 		envs          map[string]string
 		path          string
-		req           *alpb.AuditLogRequest
-		wantReq       *alpb.AuditLogRequest
+		req           *api.AuditLogRequest
+		wantReq       *api.AuditLogRequest
 		wantErrSubstr string
 	}{
 		{
 			name:    "use_config_file_when_provided",
 			path:    path.Join(dir, "valid.yaml"),
-			req:     testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
-			wantReq: testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
+			req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
 		},
 		{
 			name: "use_env_var_when_config_file_not_found",
@@ -282,8 +282,8 @@ backend:
 				"AUDIT_CLIENT_BACKEND_REMOTE_INSECURE_ENABLED":    "true",
 				"AUDIT_CLIENT_BACKEND_REMOTE_IMPERSONATE_ACCOUNT": "example@test.iam.gserviceaccount.com",
 			},
-			req:     testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
-			wantReq: testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
+			req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
 		},
 		{
 			name: "use_defaults_when_config_file_not_found",
@@ -292,8 +292,8 @@ backend:
 				"AUDIT_CLIENT_BACKEND_REMOTE_INSECURE_ENABLED":    "true",
 				"AUDIT_CLIENT_BACKEND_REMOTE_IMPERSONATE_ACCOUNT": "example@test.iam.gserviceaccount.com",
 			},
-			req:     testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
-			wantReq: testutil.ReqBuilder().WithPrincipal("abc@project.iam.gserviceaccount.com").Build(),
+			req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
 		},
 		{
 			name:          "invalid_config_file_should_error",
@@ -310,7 +310,7 @@ backend:
 			r := &fakeServer{}
 
 			addr, _ := testutil.TestFakeGRPCServer(t, func(s *grpc.Server) {
-				alpb.RegisterAuditLogAgentServer(s, r)
+				api.RegisterAuditLogAgentServer(s, r)
 			})
 
 			c, err := audit.NewClient(fromConfigFile(tc.path, envconfig.MultiLookuper(
@@ -330,7 +330,7 @@ backend:
 				// We ignore `AuditLog.Metadata` because it contains the
 				// runtime information which varies depending on the
 				// environment executing the unit test.
-				protocmp.IgnoreFields(&calpb.AuditLog{}, "metadata"),
+				protocmp.IgnoreFields(&capi.AuditLog{}, "metadata"),
 			}
 			if diff := cmp.Diff(tc.wantReq, r.gotReq, cmpopts...); diff != "" {
 				t.Errorf("audit logging backend got request (-want,+got):\n%s", diff)
@@ -345,7 +345,7 @@ func TestLoadConfig(t *testing.T) {
 	cases := []struct {
 		name        string
 		fileContent string
-		wantCfg     *alpb.Config
+		wantCfg     *api.Config
 	}{
 		{
 			name: "raw_jwt_with_just_key",
@@ -359,10 +359,10 @@ security_context:
   from_raw_jwt:
   - key: authorization
 `,
-			wantCfg: &alpb.Config{
+			wantCfg: &api.Config{
 				Version:         "v1alpha1",
-				Backend:         &alpb.Backend{Remote: &alpb.Remote{Address: "foo:443", InsecureEnabled: true}},
-				SecurityContext: &alpb.SecurityContext{FromRawJWT: []*alpb.FromRawJWT{{Key: "authorization"}}},
+				Backend:         &api.Backend{Remote: &api.Remote{Address: "foo:443", InsecureEnabled: true}},
+				SecurityContext: &api.SecurityContext{FromRawJWT: []*api.FromRawJWT{{Key: "authorization"}}},
 			},
 		},
 		{
@@ -378,10 +378,10 @@ security_context:
   - key: x-jwt-assertion
     prefix: somePrefix
 `,
-			wantCfg: &alpb.Config{
+			wantCfg: &api.Config{
 				Version:         "v1alpha1",
-				Backend:         &alpb.Backend{Remote: &alpb.Remote{Address: "foo:443", InsecureEnabled: true}},
-				SecurityContext: &alpb.SecurityContext{FromRawJWT: []*alpb.FromRawJWT{{Key: "x-jwt-assertion", Prefix: "somePrefix"}}},
+				Backend:         &api.Backend{Remote: &api.Remote{Address: "foo:443", InsecureEnabled: true}},
+				SecurityContext: &api.SecurityContext{FromRawJWT: []*api.FromRawJWT{{Key: "x-jwt-assertion", Prefix: "somePrefix"}}},
 			},
 		},
 		{
@@ -397,10 +397,10 @@ security_context:
   - key: x-jwt-assertion
     prefix:
 `,
-			wantCfg: &alpb.Config{
+			wantCfg: &api.Config{
 				Version:         "v1alpha1",
-				Backend:         &alpb.Backend{Remote: &alpb.Remote{Address: "foo:443", InsecureEnabled: true}},
-				SecurityContext: &alpb.SecurityContext{FromRawJWT: []*alpb.FromRawJWT{{Key: "x-jwt-assertion"}}},
+				Backend:         &api.Backend{Remote: &api.Remote{Address: "foo:443", InsecureEnabled: true}},
+				SecurityContext: &api.SecurityContext{FromRawJWT: []*api.FromRawJWT{{Key: "x-jwt-assertion"}}},
 			},
 		},
 		{
@@ -415,10 +415,10 @@ security_context:
   from_raw_jwt:
   - key: x-jwt-assertion
 `,
-			wantCfg: &alpb.Config{
+			wantCfg: &api.Config{
 				Version:         "v1alpha1",
-				Backend:         &alpb.Backend{Remote: &alpb.Remote{Address: "foo:443", InsecureEnabled: true}},
-				SecurityContext: &alpb.SecurityContext{FromRawJWT: []*alpb.FromRawJWT{{Key: "x-jwt-assertion"}}},
+				Backend:         &api.Backend{Remote: &api.Remote{Address: "foo:443", InsecureEnabled: true}},
+				SecurityContext: &api.SecurityContext{FromRawJWT: []*api.FromRawJWT{{Key: "x-jwt-assertion"}}},
 			},
 		},
 		{
@@ -433,10 +433,10 @@ condition:
   regex:
     principal_include: "user@example.com"
 `,
-			wantCfg: &alpb.Config{
+			wantCfg: &api.Config{
 				Version:   "v1alpha1",
-				Backend:   &alpb.Backend{Remote: &alpb.Remote{Address: "foo:443", InsecureEnabled: true}},
-				Condition: &alpb.Condition{Regex: &alpb.RegexCondition{PrincipalInclude: "user@example.com"}},
+				Backend:   &api.Backend{Remote: &api.Remote{Address: "foo:443", InsecureEnabled: true}},
+				Condition: &api.Condition{Regex: &api.RegexCondition{PrincipalInclude: "user@example.com"}},
 			},
 		},
 	}

--- a/clients/go/pkg/cloudlogging/processor_test.go
+++ b/clients/go/pkg/cloudlogging/processor_test.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/errutil"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
 )
@@ -57,8 +57,8 @@ func TestNewProcessor(t *testing.T) {
 	if p.client == nil {
 		t.Errorf("NewProcessor(%v) error: p.client should not be nil", opts)
 	}
-	if len(p.loggerByLogType) != len(alpb.AuditLogRequest_LogType_name) {
-		t.Errorf("NewProcessor(%v) got len(p.loggerByLogType)=%v, want %v", opts, len(p.loggerByLogType), len(alpb.AuditLogRequest_LogType_name))
+	if len(p.loggerByLogType) != len(api.AuditLogRequest_LogType_name) {
+		t.Errorf("NewProcessor(%v) got len(p.loggerByLogType)=%v, want %v", opts, len(p.loggerByLogType), len(api.AuditLogRequest_LogType_name))
 	}
 }
 
@@ -69,8 +69,8 @@ func TestProcessor_Process(t *testing.T) {
 		name          string
 		server        *fakeServer
 		opts          []Option
-		logReq        *alpb.AuditLogRequest
-		wantLogReq    *alpb.AuditLogRequest
+		logReq        *api.AuditLogRequest
+		wantLogReq    *api.AuditLogRequest
 		wantErrSubstr string
 	}{
 		{
@@ -78,14 +78,14 @@ func TestProcessor_Process(t *testing.T) {
 			server: &fakeServer{
 				resp: &logpb.WriteLogEntriesResponse{},
 			},
-			logReq: &alpb.AuditLogRequest{
-				Type:      alpb.AuditLogRequest_DATA_ACCESS,
+			logReq: &api.AuditLogRequest{
+				Type:      api.AuditLogRequest_DATA_ACCESS,
 				Payload:   &audit.AuditLog{ServiceName: "test-service"},
 				Labels:    map[string]string{"test-key": "test-value"},
 				Operation: &logpb.LogEntryOperation{Id: "test-id", Producer: "test-producer"},
 			},
-			wantLogReq: &alpb.AuditLogRequest{
-				Type:      alpb.AuditLogRequest_DATA_ACCESS,
+			wantLogReq: &api.AuditLogRequest{
+				Type:      api.AuditLogRequest_DATA_ACCESS,
 				Payload:   &audit.AuditLog{ServiceName: "test-service"},
 				Labels:    map[string]string{"test-key": "test-value"},
 				Operation: &logpb.LogEntryOperation{Id: "test-id", Producer: "test-producer"},
@@ -96,12 +96,12 @@ func TestProcessor_Process(t *testing.T) {
 			server: &fakeServer{
 				returnErr: status.Error(codes.FailedPrecondition, "injected err"),
 			},
-			logReq: &alpb.AuditLogRequest{
-				Type:    alpb.AuditLogRequest_DATA_ACCESS,
+			logReq: &api.AuditLogRequest{
+				Type:    api.AuditLogRequest_DATA_ACCESS,
 				Payload: &audit.AuditLog{ServiceName: "test-service"},
 			},
-			wantLogReq: &alpb.AuditLogRequest{
-				Type:    alpb.AuditLogRequest_DATA_ACCESS,
+			wantLogReq: &api.AuditLogRequest{
+				Type:    api.AuditLogRequest_DATA_ACCESS,
 				Payload: &audit.AuditLog{ServiceName: "test-service"},
 			},
 			wantErrSubstr: "synchronous write to Cloud logging failed",
@@ -112,13 +112,13 @@ func TestProcessor_Process(t *testing.T) {
 				resp: &logpb.WriteLogEntriesResponse{},
 			},
 			opts: []Option{WithDefaultBestEffort()},
-			logReq: &alpb.AuditLogRequest{
-				Type:    alpb.AuditLogRequest_DATA_ACCESS,
+			logReq: &api.AuditLogRequest{
+				Type:    api.AuditLogRequest_DATA_ACCESS,
 				Payload: &audit.AuditLog{ServiceName: "test-service"},
 				Labels:  map[string]string{"test-key": "test-value"},
 			},
-			wantLogReq: &alpb.AuditLogRequest{
-				Type:    alpb.AuditLogRequest_DATA_ACCESS,
+			wantLogReq: &api.AuditLogRequest{
+				Type:    api.AuditLogRequest_DATA_ACCESS,
 				Payload: &audit.AuditLog{ServiceName: "test-service"},
 				Labels:  map[string]string{"test-key": "test-value"},
 			},
@@ -129,12 +129,12 @@ func TestProcessor_Process(t *testing.T) {
 				returnErr: status.Error(codes.FailedPrecondition, "injected err"),
 			},
 			opts: []Option{WithDefaultBestEffort()},
-			logReq: &alpb.AuditLogRequest{
-				Type:    alpb.AuditLogRequest_DATA_ACCESS,
+			logReq: &api.AuditLogRequest{
+				Type:    api.AuditLogRequest_DATA_ACCESS,
 				Payload: &audit.AuditLog{ServiceName: "test-service"},
 			},
-			wantLogReq: &alpb.AuditLogRequest{
-				Type:    alpb.AuditLogRequest_DATA_ACCESS,
+			wantLogReq: &api.AuditLogRequest{
+				Type:    api.AuditLogRequest_DATA_ACCESS,
 				Payload: &audit.AuditLog{ServiceName: "test-service"},
 			},
 		},
@@ -144,15 +144,15 @@ func TestProcessor_Process(t *testing.T) {
 				returnErr: status.Error(codes.FailedPrecondition, "injected err"),
 			},
 			opts: []Option{WithDefaultBestEffort()},
-			logReq: &alpb.AuditLogRequest{
-				Type:    alpb.AuditLogRequest_DATA_ACCESS,
+			logReq: &api.AuditLogRequest{
+				Type:    api.AuditLogRequest_DATA_ACCESS,
 				Payload: &audit.AuditLog{ServiceName: "test-service"},
-				Mode:    alpb.AuditLogRequest_FAIL_CLOSE,
+				Mode:    api.AuditLogRequest_FAIL_CLOSE,
 			},
-			wantLogReq: &alpb.AuditLogRequest{
-				Type:    alpb.AuditLogRequest_DATA_ACCESS,
+			wantLogReq: &api.AuditLogRequest{
+				Type:    api.AuditLogRequest_DATA_ACCESS,
 				Payload: &audit.AuditLog{ServiceName: "test-service"},
-				Mode:    alpb.AuditLogRequest_FAIL_CLOSE,
+				Mode:    api.AuditLogRequest_FAIL_CLOSE,
 			},
 			wantErrSubstr: "synchronous write to Cloud logging failed",
 		},
@@ -161,15 +161,15 @@ func TestProcessor_Process(t *testing.T) {
 			server: &fakeServer{
 				returnErr: status.Error(codes.FailedPrecondition, "injected err"),
 			},
-			logReq: &alpb.AuditLogRequest{
-				Type:    alpb.AuditLogRequest_DATA_ACCESS,
+			logReq: &api.AuditLogRequest{
+				Type:    api.AuditLogRequest_DATA_ACCESS,
 				Payload: &audit.AuditLog{ServiceName: "test-service"},
-				Mode:    alpb.AuditLogRequest_BEST_EFFORT,
+				Mode:    api.AuditLogRequest_BEST_EFFORT,
 			},
-			wantLogReq: &alpb.AuditLogRequest{
-				Type:    alpb.AuditLogRequest_DATA_ACCESS,
+			wantLogReq: &api.AuditLogRequest{
+				Type:    api.AuditLogRequest_DATA_ACCESS,
 				Payload: &audit.AuditLog{ServiceName: "test-service"},
-				Mode:    alpb.AuditLogRequest_BEST_EFFORT,
+				Mode:    api.AuditLogRequest_BEST_EFFORT,
 			},
 		},
 	}
@@ -219,7 +219,7 @@ func TestProcessor_Stop(t *testing.T) {
 		name          string
 		server        *fakeServer
 		opts          []Option
-		logReqs       []*alpb.AuditLogRequest
+		logReqs       []*api.AuditLogRequest
 		wantErrSubstr string
 	}{
 		{
@@ -228,9 +228,9 @@ func TestProcessor_Stop(t *testing.T) {
 				returnErr: status.Error(codes.FailedPrecondition, "injected err"),
 			},
 			opts: []Option{WithDefaultBestEffort()},
-			logReqs: []*alpb.AuditLogRequest{
+			logReqs: []*api.AuditLogRequest{
 				{
-					Type:    alpb.AuditLogRequest_DATA_ACCESS,
+					Type:    api.AuditLogRequest_DATA_ACCESS,
 					Payload: &audit.AuditLog{ServiceName: "test-service"},
 				},
 			},
@@ -242,13 +242,13 @@ func TestProcessor_Stop(t *testing.T) {
 				returnErr: status.Error(codes.FailedPrecondition, "injected err"),
 			},
 			opts: []Option{WithDefaultBestEffort()},
-			logReqs: []*alpb.AuditLogRequest{
+			logReqs: []*api.AuditLogRequest{
 				{
-					Type:    alpb.AuditLogRequest_DATA_ACCESS,
+					Type:    api.AuditLogRequest_DATA_ACCESS,
 					Payload: &audit.AuditLog{ServiceName: "test-service"},
 				},
 				{
-					Type:    alpb.AuditLogRequest_ADMIN_ACTIVITY,
+					Type:    api.AuditLogRequest_ADMIN_ACTIVITY,
 					Payload: &audit.AuditLog{ServiceName: "test-service"},
 				},
 			},
@@ -259,9 +259,9 @@ func TestProcessor_Stop(t *testing.T) {
 			server: &fakeServer{
 				returnErr: status.Error(codes.FailedPrecondition, "injected err"),
 			},
-			logReqs: []*alpb.AuditLogRequest{
+			logReqs: []*api.AuditLogRequest{
 				{
-					Type:    alpb.AuditLogRequest_DATA_ACCESS,
+					Type:    api.AuditLogRequest_DATA_ACCESS,
 					Payload: &audit.AuditLog{ServiceName: "test-service"},
 				},
 			},

--- a/clients/go/pkg/filtering/processor.go
+++ b/clients/go/pkg/filtering/processor.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"regexp"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/audit"
 )
 
@@ -91,7 +91,7 @@ func NewPrincipalEmailMatcher(opts ...Option) (*PrincipalEmailMatcher, error) {
 //   2. If include != nil and exclude == nil, we only pass the request when the principal matches include.
 //   3. If include == nil and exclude != nil, we only drop the request when the principal matches exclude.
 //   4. If include != nil and exclude != nil, we drop the request when the principal doesn't match include and matches exclude.
-func (p *PrincipalEmailMatcher) Process(_ context.Context, logReq *alpb.AuditLogRequest) error {
+func (p *PrincipalEmailMatcher) Process(_ context.Context, logReq *api.AuditLogRequest) error {
 	if len(p.includes) == 0 && len(p.excludes) == 0 {
 		return nil
 	}

--- a/clients/go/pkg/filtering/processor_test.go
+++ b/clients/go/pkg/filtering/processor_test.go
@@ -23,7 +23,7 @@ import (
 	cal "google.golang.org/genproto/googleapis/cloud/audit"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/audit"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/errutil"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
@@ -78,40 +78,40 @@ func TestPrincipalEmailMatcher_Process(t *testing.T) {
 	tests := []struct {
 		name       string
 		opts       []Option
-		logReq     *alpb.AuditLogRequest
-		wantLogReq *alpb.AuditLogRequest
+		logReq     *api.AuditLogRequest
+		wantLogReq *api.AuditLogRequest
 		wantErr    error
 	}{
 		{
 			name:       "should_succeed_when_include_and_exclude_are_nil",
-			logReq:     testutil.ReqBuilder().Build(),
-			wantLogReq: testutil.ReqBuilder().Build(),
+			logReq:     testutil.NewRequest(),
+			wantLogReq: testutil.NewRequest(),
 		},
 		{
 			name:       "should_succeed_when_include_matches_and_exclude_is_nil",
 			opts:       []Option{WithIncludes("foo@google.com")},
-			logReq:     testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
-			wantLogReq: testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
+			logReq:     testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
+			wantLogReq: testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
 		},
 		{
 			name:       "should_fail_precondition_when_include_mismatches_and_exclude_is_nil",
 			opts:       []Option{WithIncludes("foo@google.com")},
-			logReq:     testutil.ReqBuilder().WithPrincipal("bar@google.com").Build(),
-			wantLogReq: testutil.ReqBuilder().WithPrincipal("bar@google.com").Build(),
+			logReq:     testutil.NewRequest(testutil.WithPrincipal("bar@google.com")),
+			wantLogReq: testutil.NewRequest(testutil.WithPrincipal("bar@google.com")),
 			wantErr:    audit.ErrFailedPrecondition,
 		},
 		{
 			name:       "should_fail_precondition_when_exclude_matches_and_include_is_nil",
 			opts:       []Option{WithExcludes("foo@google.com")},
-			logReq:     testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
-			wantLogReq: testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
+			logReq:     testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
+			wantLogReq: testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
 			wantErr:    audit.ErrFailedPrecondition,
 		},
 		{
 			name:       "should_succeed_when_exclude_mismatches_and_include_is_nil",
 			opts:       []Option{WithExcludes("foo@google.com")},
-			logReq:     testutil.ReqBuilder().WithPrincipal("bar@google.com").Build(),
-			wantLogReq: testutil.ReqBuilder().WithPrincipal("bar@google.com").Build(),
+			logReq:     testutil.NewRequest(testutil.WithPrincipal("bar@google.com")),
+			wantLogReq: testutil.NewRequest(testutil.WithPrincipal("bar@google.com")),
 		},
 		{
 			name: "should_fail_precondition_when_include_mismatches_and_exclude_matches",
@@ -119,8 +119,8 @@ func TestPrincipalEmailMatcher_Process(t *testing.T) {
 				WithIncludes("foo@google.com"),
 				WithExcludes("bar@google.com"),
 			},
-			logReq:     testutil.ReqBuilder().WithPrincipal("bar@google.com").Build(),
-			wantLogReq: testutil.ReqBuilder().WithPrincipal("bar@google.com").Build(),
+			logReq:     testutil.NewRequest(testutil.WithPrincipal("bar@google.com")),
+			wantLogReq: testutil.NewRequest(testutil.WithPrincipal("bar@google.com")),
 			wantErr:    audit.ErrFailedPrecondition,
 		},
 		{
@@ -129,8 +129,8 @@ func TestPrincipalEmailMatcher_Process(t *testing.T) {
 				WithIncludes("foo@google.com"),
 				WithExcludes("bar@google.com"),
 			},
-			logReq:     testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
-			wantLogReq: testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
+			logReq:     testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
+			wantLogReq: testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
 		},
 		{
 			name: "should_succeed_when_include_matches_and_exclude_matches",
@@ -138,8 +138,8 @@ func TestPrincipalEmailMatcher_Process(t *testing.T) {
 				WithIncludes("foo@google.com"),
 				WithExcludes("@google.com"),
 			},
-			logReq:     testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
-			wantLogReq: testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
+			logReq:     testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
+			wantLogReq: testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
 		},
 		{
 			name: "should_work_as_intended_with_multiple_includes_and_excludes",
@@ -147,16 +147,16 @@ func TestPrincipalEmailMatcher_Process(t *testing.T) {
 				WithIncludes("foo@google.com", "bar@google.com"),
 				WithExcludes("baz@google.com", "qux@google.com"),
 			},
-			logReq:     testutil.ReqBuilder().WithPrincipal("bar@google.com").Build(),
-			wantLogReq: testutil.ReqBuilder().WithPrincipal("bar@google.com").Build(),
+			logReq:     testutil.NewRequest(testutil.WithPrincipal("bar@google.com")),
+			wantLogReq: testutil.NewRequest(testutil.WithPrincipal("bar@google.com")),
 		},
 		{
 			name: "empty_string_as_exclude_is_a_noop",
 			opts: []Option{
 				WithExcludes(""),
 			},
-			logReq:     testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
-			wantLogReq: testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
+			logReq:     testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
+			wantLogReq: testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
 		},
 		{
 			name: "empty_string_as_include_is_a_noop",
@@ -164,8 +164,8 @@ func TestPrincipalEmailMatcher_Process(t *testing.T) {
 				WithIncludes(""),
 				WithExcludes("."),
 			},
-			logReq:     testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
-			wantLogReq: testutil.ReqBuilder().WithPrincipal("foo@google.com").Build(),
+			logReq:     testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
+			wantLogReq: testutil.NewRequest(testutil.WithPrincipal("foo@google.com")),
 			wantErr:    audit.ErrFailedPrecondition,
 		},
 		{
@@ -173,10 +173,10 @@ func TestPrincipalEmailMatcher_Process(t *testing.T) {
 			opts: []Option{
 				WithIncludes("foo@google.com"),
 			},
-			logReq: &alpb.AuditLogRequest{
+			logReq: &api.AuditLogRequest{
 				Payload: &cal.AuditLog{},
 			},
-			wantLogReq: &alpb.AuditLogRequest{
+			wantLogReq: &api.AuditLogRequest{
 				Payload: &cal.AuditLog{},
 			},
 			wantErr: audit.ErrInvalidRequest,

--- a/clients/go/pkg/remote/processor.go
+++ b/clients/go/pkg/remote/processor.go
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 )
 
 // Option is the option to set up a remote audit log processor.
@@ -52,7 +52,7 @@ type grpcAuthOptions interface {
 type Processor struct {
 	address     string
 	conn        *grpc.ClientConn
-	client      alpb.AuditLogAgentClient
+	client      api.AuditLogAgentClient
 	authOpts    grpcAuthOptions
 	rawDialOpts []grpc.DialOption
 }
@@ -88,12 +88,12 @@ func NewProcessor(address string, opts ...Option) (*Processor, error) {
 	}
 
 	p.conn = conn
-	p.client = alpb.NewAuditLogAgentClient(conn)
+	p.client = api.NewAuditLogAgentClient(conn)
 	return p, nil
 }
 
 // Process processes the audit log request by calling a remote service.
-func (p *Processor) Process(ctx context.Context, logReq *alpb.AuditLogRequest) error {
+func (p *Processor) Process(ctx context.Context, logReq *api.AuditLogRequest) error {
 	var authCallOpts []grpc.CallOption
 	if p.authOpts != nil {
 		var err error

--- a/clients/go/pkg/remote/processor_test.go
+++ b/clients/go/pkg/remote/processor_test.go
@@ -27,19 +27,19 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
 )
 
 type fakeServer struct {
-	alpb.UnimplementedAuditLogAgentServer
+	api.UnimplementedAuditLogAgentServer
 
-	gotReq    *alpb.AuditLogRequest
-	resp      *alpb.AuditLogResponse
+	gotReq    *api.AuditLogRequest
+	resp      *api.AuditLogResponse
 	returnErr error
 }
 
-func (s *fakeServer) ProcessLog(_ context.Context, logReq *alpb.AuditLogRequest) (*alpb.AuditLogResponse, error) {
+func (s *fakeServer) ProcessLog(_ context.Context, logReq *api.AuditLogRequest) (*api.AuditLogResponse, error) {
 	s.gotReq = logReq
 	return s.resp, s.returnErr
 }
@@ -50,46 +50,46 @@ func TestProcessor_Process_Insecure(t *testing.T) {
 	cases := []struct {
 		name          string
 		server        *fakeServer
-		req           *alpb.AuditLogRequest
-		wantSentReq   *alpb.AuditLogRequest
-		wantResultReq *alpb.AuditLogRequest
+		req           *api.AuditLogRequest
+		wantSentReq   *api.AuditLogRequest
+		wantResultReq *api.AuditLogRequest
 		wantErr       error
 	}{{
 		name: "success_log_req_no_change",
 		server: &fakeServer{
-			resp: &alpb.AuditLogResponse{
-				Result: testutil.ReqBuilder().WithLabels(map[string]string{"foo": "bar"}).Build(),
+			resp: &api.AuditLogResponse{
+				Result: testutil.NewRequest(testutil.WithLabels(map[string]string{"foo": "bar"})),
 			},
 		},
-		req:           testutil.ReqBuilder().WithLabels(map[string]string{"foo": "bar"}).Build(),
-		wantSentReq:   testutil.ReqBuilder().WithLabels(map[string]string{"foo": "bar"}).Build(),
-		wantResultReq: testutil.ReqBuilder().WithLabels(map[string]string{"foo": "bar"}).Build(),
+		req:           testutil.NewRequest(testutil.WithLabels(map[string]string{"foo": "bar"})),
+		wantSentReq:   testutil.NewRequest(testutil.WithLabels(map[string]string{"foo": "bar"})),
+		wantResultReq: testutil.NewRequest(testutil.WithLabels(map[string]string{"foo": "bar"})),
 	}, {
 		name: "success_log_req_updated",
 		server: &fakeServer{
-			resp: &alpb.AuditLogResponse{
-				Result: testutil.ReqBuilder().WithLabels(
+			resp: &api.AuditLogResponse{
+				Result: testutil.NewRequest(testutil.WithLabels(
 					map[string]string{
 						"foo": "bar",
 						"abc": "123",
-					}).Build(),
+					})),
 			},
 		},
-		req:         testutil.ReqBuilder().WithLabels(map[string]string{"foo": "bar"}).Build(),
-		wantSentReq: testutil.ReqBuilder().WithLabels(map[string]string{"foo": "bar"}).Build(),
-		wantResultReq: testutil.ReqBuilder().WithLabels(
+		req:         testutil.NewRequest(testutil.WithLabels(map[string]string{"foo": "bar"})),
+		wantSentReq: testutil.NewRequest(testutil.WithLabels(map[string]string{"foo": "bar"})),
+		wantResultReq: testutil.NewRequest(testutil.WithLabels(
 			map[string]string{
 				"foo": "bar",
 				"abc": "123",
-			}).Build(),
+			})),
 	}, {
 		name: "server_error",
 		server: &fakeServer{
 			returnErr: status.Error(codes.FailedPrecondition, "injected err"),
 		},
-		req:           testutil.ReqBuilder().WithLabels(map[string]string{"foo": "bar"}).Build(),
-		wantSentReq:   testutil.ReqBuilder().WithLabels(map[string]string{"foo": "bar"}).Build(),
-		wantResultReq: testutil.ReqBuilder().WithLabels(map[string]string{"foo": "bar"}).Build(),
+		req:           testutil.NewRequest(testutil.WithLabels(map[string]string{"foo": "bar"})),
+		wantSentReq:   testutil.NewRequest(testutil.WithLabels(map[string]string{"foo": "bar"})),
+		wantResultReq: testutil.NewRequest(testutil.WithLabels(map[string]string{"foo": "bar"})),
 		wantErr:       status.Error(codes.FailedPrecondition, "injected err"),
 	}}
 
@@ -100,7 +100,7 @@ func TestProcessor_Process_Insecure(t *testing.T) {
 
 			s := grpc.NewServer()
 			defer s.Stop()
-			alpb.RegisterAuditLogAgentServer(s, tc.server)
+			api.RegisterAuditLogAgentServer(s, tc.server)
 
 			lis, err := net.Listen("tcp", "localhost:0")
 			if err != nil {

--- a/clients/go/pkg/testutil/request.go
+++ b/clients/go/pkg/testutil/request.go
@@ -17,22 +17,17 @@
 package testutil
 
 import (
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+
 	"google.golang.org/genproto/googleapis/cloud/audit"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// RequestBuilder is intended to be used as a helper for test classes.
-// It builds basic AuditLogRequests with sane defaults for testing,
-// and exposes a builder in order to create requests for tests that have
-// specific requirements.
-type RequestBuilder struct {
-	auditLogRequest *alpb.AuditLogRequest
-}
+type RequestOptions func(r *api.AuditLogRequest) *api.AuditLogRequest
 
-func ReqBuilder() *RequestBuilder {
-	return &RequestBuilder{auditLogRequest: &alpb.AuditLogRequest{
-		Type: alpb.AuditLogRequest_DATA_ACCESS,
+func NewRequest(opts ...RequestOptions) *api.AuditLogRequest {
+	request := &api.AuditLogRequest{
+		Type: api.AuditLogRequest_DATA_ACCESS,
 		Payload: &audit.AuditLog{
 			ServiceName:  "test-service",
 			ResourceName: "test-resource",
@@ -40,39 +35,51 @@ func ReqBuilder() *RequestBuilder {
 				PrincipalEmail: "user@example.com",
 			},
 		},
-	}}
+	}
+	for _, opt := range opts {
+		request = opt(request)
+	}
+	return request
 }
 
-func (b *RequestBuilder) WithLabels(labels map[string]string) *RequestBuilder {
-	b.auditLogRequest.Labels = labels
-	return b
+func WithLabels(labels map[string]string) RequestOptions {
+	return func(r *api.AuditLogRequest) *api.AuditLogRequest {
+		r.Labels = labels
+		return r
+	}
 }
 
-func (b *RequestBuilder) WithPrincipal(principal string) *RequestBuilder {
-	b.auditLogRequest.Payload.AuthenticationInfo.PrincipalEmail = principal
-	return b
+func WithPrincipal(principal string) RequestOptions {
+	return func(r *api.AuditLogRequest) *api.AuditLogRequest {
+		r.Payload.AuthenticationInfo.PrincipalEmail = principal
+		return r
+	}
 }
 
-func (b *RequestBuilder) WithMethodName(methodName string) *RequestBuilder {
-	b.auditLogRequest.Payload.MethodName = methodName
-	return b
+func WithMethodName(method string) RequestOptions {
+	return func(r *api.AuditLogRequest) *api.AuditLogRequest {
+		r.Payload.MethodName = method
+		return r
+	}
 }
 
-func (b *RequestBuilder) WithServiceName(serviceName string) *RequestBuilder {
-	b.auditLogRequest.Payload.ServiceName = serviceName
-	return b
+func WithServiceName(service string) RequestOptions {
+	return func(r *api.AuditLogRequest) *api.AuditLogRequest {
+		r.Payload.ServiceName = service
+		return r
+	}
 }
 
-func (b *RequestBuilder) WithMetadata(metadata *structpb.Struct) *RequestBuilder {
-	b.auditLogRequest.Payload.Metadata = metadata
-	return b
+func WithMetadata(metadata *structpb.Struct) RequestOptions {
+	return func(r *api.AuditLogRequest) *api.AuditLogRequest {
+		r.Payload.Metadata = metadata
+		return r
+	}
 }
 
-func (b *RequestBuilder) WithMode(logMode alpb.AuditLogRequest_LogMode) *RequestBuilder {
-	b.auditLogRequest.Mode = logMode
-	return b
-}
-
-func (b *RequestBuilder) Build() *alpb.AuditLogRequest {
-	return b.auditLogRequest
+func WithMode(mode api.AuditLogRequest_LogMode) RequestOptions {
+	return func(r *api.AuditLogRequest) *api.AuditLogRequest {
+		r.Mode = mode
+		return r
+	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/audit"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/cloudlogging"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/trace"
@@ -83,7 +83,7 @@ func realMain(ctx context.Context) error {
 		otelgrpc.UnaryServerInterceptor(),
 		zlogger.GRPCInterceptor(logger),
 	))
-	alpb.RegisterAuditLogAgentServer(s, logAgent)
+	api.RegisterAuditLogAgentServer(s, logAgent)
 	reflection.Register(s)
 
 	lis, err := net.Listen("tcp", ":"+cfg.Port)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -22,13 +22,13 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/audit"
 )
 
 // AuditLogAgent is the implementation of the audit log agent server.
 type AuditLogAgent struct {
-	alpb.UnimplementedAuditLogAgentServer
+	api.UnimplementedAuditLogAgentServer
 
 	client *audit.Client
 }
@@ -39,12 +39,12 @@ func NewAuditLogAgent(client *audit.Client) (*AuditLogAgent, error) {
 }
 
 // ProcessLog processes the log requests by calling the internal client.
-func (a *AuditLogAgent) ProcessLog(ctx context.Context, logReq *alpb.AuditLogRequest) (*alpb.AuditLogResponse, error) {
+func (a *AuditLogAgent) ProcessLog(ctx context.Context, logReq *api.AuditLogRequest) (*api.AuditLogResponse, error) {
 	if err := a.client.Log(ctx, logReq); err != nil {
 		return nil, codifyErr(err)
 	}
 
-	return &alpb.AuditLogResponse{
+	return &api.AuditLogResponse{
 		Result: logReq,
 	}, nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -29,21 +29,21 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	alpb "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/audit"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
 )
 
 type fakeLogProcessor struct {
-	gotReq    *alpb.AuditLogRequest
-	updateReq *alpb.AuditLogRequest
+	gotReq    *api.AuditLogRequest
+	updateReq *api.AuditLogRequest
 	returnErr error
 }
 
-func (p *fakeLogProcessor) Process(_ context.Context, logReq *alpb.AuditLogRequest) error {
-	reqClone, ok := proto.Clone(logReq).(*alpb.AuditLogRequest)
+func (p *fakeLogProcessor) Process(_ context.Context, logReq *api.AuditLogRequest) error {
+	reqClone, ok := proto.Clone(logReq).(*api.AuditLogRequest)
 	if !ok {
-		return fmt.Errorf("expected *alpb.AuditLogRequest, got %T", reqClone)
+		return fmt.Errorf("expected *api.AuditLogRequest, got %T", reqClone)
 	}
 
 	p.gotReq = reqClone
@@ -59,56 +59,56 @@ func TestAuditLogAgent_ProcessLog(t *testing.T) {
 
 	cases := []struct {
 		name        string
-		req         *alpb.AuditLogRequest
+		req         *api.AuditLogRequest
 		p           *fakeLogProcessor
-		wantSentReq *alpb.AuditLogRequest
-		wantResp    *alpb.AuditLogResponse
+		wantSentReq *api.AuditLogRequest
+		wantResp    *api.AuditLogResponse
 		wantErr     error
 	}{{
 		name:        "success_no_update",
-		req:         testutil.ReqBuilder().Build(),
+		req:         testutil.NewRequest(),
 		p:           &fakeLogProcessor{},
-		wantSentReq: testutil.ReqBuilder().WithMode(alpb.AuditLogRequest_FAIL_CLOSE).Build(),
-		wantResp: &alpb.AuditLogResponse{
-			Result: testutil.ReqBuilder().WithMode(alpb.AuditLogRequest_FAIL_CLOSE).Build(),
+		wantSentReq: testutil.NewRequest(testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
+		wantResp: &api.AuditLogResponse{
+			Result: testutil.NewRequest(testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
 		},
 	}, {
 		name: "success_with_update",
-		req:  testutil.ReqBuilder().WithServiceName("test-service").Build(),
+		req:  testutil.NewRequest(testutil.WithServiceName("test-service")),
 		p: &fakeLogProcessor{
-			updateReq: testutil.ReqBuilder().WithServiceName("bar").WithMethodName("Do").Build(),
+			updateReq: testutil.NewRequest(testutil.WithServiceName("bar"), testutil.WithMethodName("Do")),
 		},
-		wantSentReq: testutil.ReqBuilder().WithServiceName("test-service").WithMode(alpb.AuditLogRequest_FAIL_CLOSE).Build(),
-		wantResp: &alpb.AuditLogResponse{
-			Result: testutil.ReqBuilder().WithServiceName("bar").WithMethodName("Do").WithMode(alpb.AuditLogRequest_FAIL_CLOSE).Build(),
+		wantSentReq: testutil.NewRequest(testutil.WithServiceName("test-service"), testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
+		wantResp: &api.AuditLogResponse{
+			Result: testutil.NewRequest(testutil.WithServiceName("bar"), testutil.WithMethodName("Do"), testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
 		},
 	}, {
 		name: "internal_failure",
-		req:  testutil.ReqBuilder().WithServiceName("test-service").Build(),
+		req:  testutil.NewRequest(testutil.WithServiceName("test-service")),
 		p: &fakeLogProcessor{
 			returnErr: fmt.Errorf("injected err"),
 		},
-		wantSentReq: testutil.ReqBuilder().WithServiceName("test-service").WithMode(alpb.AuditLogRequest_FAIL_CLOSE).Build(),
+		wantSentReq: testutil.NewRequest(testutil.WithServiceName("test-service"), testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
 		wantErr:     status.Error(codes.Internal, "failed to execute backend *server.fakeLogProcessor: injected err"),
 	}, {
 		name: "invaid_argument_failure",
-		req:  testutil.ReqBuilder().WithServiceName("test-service").Build(),
+		req:  testutil.NewRequest(testutil.WithServiceName("test-service")),
 		p: &fakeLogProcessor{
 			returnErr: fmt.Errorf("injected: %w", audit.ErrInvalidRequest),
 		},
-		wantSentReq: testutil.ReqBuilder().WithServiceName("test-service").WithMode(alpb.AuditLogRequest_FAIL_CLOSE).Build(),
+		wantSentReq: testutil.NewRequest(testutil.WithServiceName("test-service"), testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
 		wantErr:     status.Error(codes.InvalidArgument, "failed to execute backend *server.fakeLogProcessor: injected: invalid audit log request"),
 	}, {
 		name: "invaid_argument_failure_with_requst_overriding_fail_close",
-		req:  testutil.ReqBuilder().WithServiceName("test-service").WithMode(alpb.AuditLogRequest_BEST_EFFORT).Build(),
+		req:  testutil.NewRequest(testutil.WithServiceName("test-service"), testutil.WithMode(api.AuditLogRequest_BEST_EFFORT)),
 		p: &fakeLogProcessor{
 			returnErr: fmt.Errorf("injected: %w", audit.ErrInvalidRequest),
 		},
-		wantSentReq: testutil.ReqBuilder().WithServiceName("test-service").WithMode(alpb.AuditLogRequest_BEST_EFFORT).Build(),
-		wantResp: &alpb.AuditLogResponse{
+		wantSentReq: testutil.NewRequest(testutil.WithServiceName("test-service"), testutil.WithMode(api.AuditLogRequest_BEST_EFFORT)),
+		wantResp: &api.AuditLogResponse{
 			// TODO: We want to swallow errors in the client on best effort, but that means the server will return
 			// with this output. Do we want any indication in the response that the audit log hasn't ocurred?
-			Result: testutil.ReqBuilder().WithServiceName("test-service").WithMode(alpb.AuditLogRequest_BEST_EFFORT).Build(),
+			Result: testutil.NewRequest(testutil.WithServiceName("test-service"), testutil.WithMode(api.AuditLogRequest_BEST_EFFORT)),
 		},
 	}}
 
@@ -121,7 +121,7 @@ func TestAuditLogAgent_ProcessLog(t *testing.T) {
 			s := grpc.NewServer()
 			defer s.Stop()
 
-			ac, err := audit.NewClient(audit.WithBackend(tc.p), audit.WithLogMode(alpb.AuditLogRequest_FAIL_CLOSE))
+			ac, err := audit.NewClient(audit.WithBackend(tc.p), audit.WithLogMode(api.AuditLogRequest_FAIL_CLOSE))
 			if err != nil {
 				t.Fatalf("Failed to create audit client: %v", err)
 			}
@@ -129,7 +129,7 @@ func TestAuditLogAgent_ProcessLog(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create audit log agent server: %v", err)
 			}
-			alpb.RegisterAuditLogAgentServer(s, server)
+			api.RegisterAuditLogAgentServer(s, server)
 
 			lis, err := net.Listen("tcp", "localhost:0")
 			if err != nil {
@@ -147,7 +147,7 @@ func TestAuditLogAgent_ProcessLog(t *testing.T) {
 				t.Fatalf("Failed to establish gRPC conn: %v", err)
 			}
 
-			client := alpb.NewAuditLogAgentClient(conn)
+			client := api.NewAuditLogAgentClient(conn)
 			gotResp, err := client.ProcessLog(context.Background(), tc.req)
 
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {


### PR DESCRIPTION
* remove builder pattern in favor of go idiomatic opts pattern
* rename alpb to api throughout, it's more than a protobuf package, api is more descriptive