### PR TITLE
chore: do not use child repositories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       PROJECT_ID: 'lumberjack-dev-infra'
       PROJECT_NUMBER: '638387980668'
       REGISTRY: 'us-docker.pkg.dev'
-      REPO: 'us-docker.pkg.dev/lumberjack-dev-infra/images/lumberjack'
+      REPO: 'us-docker.pkg.dev/lumberjack-dev-infra/images'
       TAG: "${{ github.event.inputs.tag || github.ref_type == 'branch' && github.sha || github.ref_name }}"
 
     permissions:

--- a/scripts/build_server.sh
+++ b/scripts/build_server.sh
@@ -37,7 +37,7 @@ fi
 
 docker build \
   --file="$(dirname "$0")/server.dockerfile" \
-  --tag="${REPO}/server:${TAG}" \
+  --tag="${REPO}/lumberjack-server:${TAG}" \
   ${ROOT}
 
-docker push "${REPO}/server:${TAG}"
+docker push "${REPO}/lumberjack-server:${TAG}"

--- a/terraform/modules/ci-run-with-server/main.tf
+++ b/terraform/modules/ci-run-with-server/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   tag  = var.use_random_tag ? uuid() : var.tag
-  repo = "${var.artifact_registry_location}-docker.pkg.dev/${var.server_project_id}/images/lumberjack"
+  repo = "${var.artifact_registry_location}-docker.pkg.dev/${var.server_project_id}/images"
   env_vars = {
     "AUDIT_CLIENT_BACKEND_REMOTE_ADDRESS" : "${trimprefix(module.server_service.audit_log_server_url, "https://")}:443",
   }
@@ -41,7 +41,7 @@ resource "null_resource" "server_build" {
 module "server_service" {
   source       = "../server-service"
   project_id   = var.server_project_id
-  server_image = "${local.repo}/server:${local.tag}"
+  server_image = "${local.repo}/lumberjack-server:${local.tag}"
   service_name = var.service_name
 
   // Disable dedicated service account for audit logging server.

--- a/terraform/modules/e2e/main.tf
+++ b/terraform/modules/e2e/main.tf
@@ -246,7 +246,7 @@ resource "null_resource" "build" {
     environment = {
       PROJECT_ID = google_project.server_project.project_id
       TAG        = local.tag
-      REPO       = "${var.registry_location}-docker.pkg.dev/${google_project.server_project.project_id}/images/lumberjack"
+      REPO       = "${var.registry_location}-docker.pkg.dev/${google_project.server_project.project_id}/images"
     }
 
     command = "${path.module}/../../../scripts/build_server.sh"
@@ -260,7 +260,7 @@ resource "null_resource" "build" {
 module "server_service" {
   source       = "../server-service"
   project_id   = google_project.server_project.project_id
-  server_image = "${var.registry_location}-docker.pkg.dev/${google_project.server_project.project_id}/images/lumberjack/server:${local.tag}"
+  server_image = "${var.registry_location}-docker.pkg.dev/${google_project.server_project.project_id}/images/lumberjack-server:${local.tag}"
   service_name = var.service_name
 
   # Give the list of IAM entities in the input variables

--- a/terraform/modules/shell-app/main.tf
+++ b/terraform/modules/shell-app/main.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  repo = "${var.artifact_registry_location}-docker.pkg.dev/${var.project_id}/images/lumberjack"
+  repo = "${var.artifact_registry_location}-docker.pkg.dev/${var.project_id}/images"
   tag  = var.use_random_tag ? uuid() : var.tag
   default_server_env_vars = {
   }

--- a/terraform/modules_validation/main.tf
+++ b/terraform/modules_validation/main.tf
@@ -67,7 +67,7 @@ module "server-sink" {
 module "server-service" {
   source       = "../modules/server-service"
   project_id   = "lumberjack-server"
-  server_image = "gcr.io/lumberjack-server/lumberjack/server:fake"
+  server_image = "gcr.io/lumberjack-server/lumberjack-server:fake"
 }
 
 module "bigquery-destination" {


### PR DESCRIPTION
Child repositories are not well-supported across the Docker ecosystem. By using a slash in the container name, we're creating a child docker container. This creates problems with community tooling that generally do not support child containers.

Part of https://github.com/abcxyz/lumberjack/issues/241