### PR TITLE
Switch default config to /etc/lumberjack/config.yaml

### DIFF
--- a/clients/go/pkg/auditopt/config.go
+++ b/clients/go/pkg/auditopt/config.go
@@ -41,7 +41,7 @@ import (
 	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 )
 
-const DefaultConfigFilePath = "/etc/auditlogging/config.yaml"
+const DefaultConfigFilePath = "/etc/lumberjack/config.yaml"
 
 // MustFromConfigFile specifies a config file to configure the
 // audit client. `path` is required, and if the config file is

--- a/clients/go/test/grpc-app/Dockerfile
+++ b/clients/go/test/grpc-app/Dockerfile
@@ -33,7 +33,7 @@ COPY --from=builder /tmp/etc-passwd /etc/passwd
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/app /app
 # Copy the client config.
-COPY test/grpc-app/config.yaml /etc/auditlogging/config.yaml
+COPY test/grpc-app/config.yaml /etc/lumberjack/config.yaml
 USER nobody
 
 # Run the web service on container startup.


### PR DESCRIPTION
Linux tools generally use the same name as their project. The previous value of "auditlogging" was generic.