### PR TITLE
Update to Go 1.19 and prep support for arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: 'Setup Go'
         uses: 'actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2' # ratchet:actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - name: 'Cache dependencies'
         uses: 'actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09' # ratchet:actions/cache@v3

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -28,10 +28,17 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b' # ratchet:actions/checkout@v3
 
+      - name: 'Setup qemu'
+        uses: 'docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8' # ratchet:docker/setup-qemu-action@v2
+
+      - name: 'Setup buildx'
+        id: buildx
+        uses: 'docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6' # ratchet:docker/setup-buildx-action@v2
+
       - name: 'Setup Go'
         uses: 'actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2' # ratchet:actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - name: 'Cache dependencies'
         uses: 'actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09' # ratchet:actions/cache@v3

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -18,26 +18,26 @@ jobs:
   go_lint_server:
     uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@main'
     with:
-      go_version: '1.18'
+      go_version: '1.19'
 
   go_test_server:
     uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main'
     with:
-      go_version: '1.18'
+      go_version: '1.19'
       go_packages: './cmd/... ./pkg/... ./third_party/...'
 
   # Go client
   go_lint_client:
     uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@main'
     with:
-      go_version: '1.18'
+      go_version: '1.19'
       directory: 'clients/go'
 
   go_test_client:
     uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main'
     with:
       directory: 'clients/go'
-      go_version: '1.18'
+      go_version: '1.19'
       go_packages: './...'
 
   # Java client

--- a/clients/go/go.mod
+++ b/clients/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/abcxyz/lumberjack/clients/go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/clients/go/test/grpc-app/Dockerfile
+++ b/clients/go/test/grpc-app/Dockerfile
@@ -1,30 +1,21 @@
-# Use the offical golang image to create a binary.
-FROM golang:1.18 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.19 AS builder
 
-# Disable CGO to get a static go binary.
+ENV PORT=8080
 ENV CGO_ENABLED=0
+ENV GOPROXY=https://proxy.golang.org,direct
 
-# Create and change to the app directory.
 WORKDIR /go/src/app
-
-# Copy local code to the container image.
 COPY . .
 
-# Build a single static binary.
-#   - "a" recompile symbols for our production build
-#   - "trimpath" makes stacktraces nicer and gets a reproducible build
-#   - "ldflags" strip the binary and tells it to compile statically
 RUN go build \
   -a \
   -trimpath \
-  -ldflags "-s -w -extldflags '-static'" \
+  -ldflags "-s -w -extldflags='-static'" \
   -o /go/bin/app \
   ./test/grpc-app
 
-# Strip symbols from binary to make it smaller.
 RUN strip -s /go/bin/app
 
-# Create the user `nobody`.
 RUN echo "nobody:*:65534:65534:nobody:/:/bin/false" > /tmp/etc-passwd
 
 # Use a scratch image to host our binary.
@@ -32,9 +23,10 @@ FROM scratch
 COPY --from=builder /tmp/etc-passwd /etc/passwd
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/app /app
+
 # Copy the client config.
 COPY test/grpc-app/config.yaml /etc/lumberjack/config.yaml
 USER nobody
 
-# Run the web service on container startup.
+EXPOSE 8080
 ENTRYPOINT ["/app"]

--- a/clients/go/test/grpc-app/build.sh
+++ b/clients/go/test/grpc-app/build.sh
@@ -34,5 +34,8 @@ fi
 GO_ROOT="$(cd "$(dirname "$0")/../.." &>/dev/null; pwd -P)"
 IMAGE_NAME=${REPO}/${APP_NAME}:${TAG}
 
-docker build -f ${GO_ROOT}/test/grpc-app/Dockerfile -t ${IMAGE_NAME} ${GO_ROOT}
-docker push ${IMAGE_NAME}
+docker buildx build \
+  --file ${GO_ROOT}/test/grpc-app/Dockerfile \
+  --tag ${IMAGE_NAME} \
+  --push \
+  ${GO_ROOT}

--- a/clients/go/test/shell/Dockerfile
+++ b/clients/go/test/shell/Dockerfile
@@ -1,30 +1,21 @@
-# Use the offical golang image to create a binary.
-FROM golang:1.18 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.19 AS builder
 
-# Disable CGO to get a static go binary.
+ENV PORT=8080
 ENV CGO_ENABLED=0
+ENV GOPROXY=https://proxy.golang.org,direct
 
-# Create and change to the app directory.
 WORKDIR /go/src/app
-
-# Copy local code to the container image.
 COPY . .
 
-# Build a single static binary.
-#   - "a" recompile symbols for our production build
-#   - "trimpath" makes stacktraces nicer and gets a reproducible build
-#   - "ldflags" strip the binary and tells it to compile statically
 RUN go build \
   -a \
   -trimpath \
-  -ldflags "-s -w -extldflags '-static'" \
+  -ldflags "-s -w -extldflags='-static'" \
   -o /go/bin/app \
   ./test/shell
 
-# Strip symbols from binary to make it smaller.
 RUN strip -s /go/bin/app
 
-# Create the user `nobody`.
 RUN echo "nobody:*:65534:65534:nobody:/:/bin/false" > /tmp/etc-passwd
 
 # Use a scratch image to host our binary.
@@ -34,5 +25,5 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/bin/app /app
 USER nobody
 
-# Run the web service on container startup.
+EXPOSE 8080
 ENTRYPOINT ["/app"]

--- a/clients/go/test/shell/README.md
+++ b/clients/go/test/shell/README.md
@@ -46,16 +46,14 @@ automated and manual testing.
     ```
 
 1.  Execute the following steps from the Lumberjack Go client directory, where
-    `go.mod` is located. Build and package the Shell app into a container:
+    `go.mod` is located. Build and push the Shell app into a container:
 
     ```sh
-    docker build -t us-docker.pkg.dev/${APP_PROJECT}/images/logging-shell:${LDAP} -f test/shell/Dockerfile .
-    ```
-
-1.  Push the container to Artifact Registry:
-
-    ```sh
-    docker push us-docker.pkg.dev/${APP_PROJECT}/images/logging-shell:${LDAP}
+    docker buildx build \
+      --file "test/shell/Dockerfile" \
+      --tag "us-docker.pkg.dev/${APP_PROJECT}/images/logging-shell:${LDAP}" \
+      --push \
+      .
     ```
 
 1.  Deploy the Shell app to Cloud Run

--- a/clients/go/test/shell/build.sh
+++ b/clients/go/test/shell/build.sh
@@ -34,5 +34,8 @@ fi
 GO_ROOT="$(cd "$(dirname "$0")/../.." &>/dev/null; pwd -P)"
 IMAGE_NAME=${REPO}/${APP_NAME}:${TAG}
 
-docker build -f ${GO_ROOT}/test/shell/Dockerfile -t ${IMAGE_NAME} ${GO_ROOT}
-docker push ${IMAGE_NAME}
+docker buildx build \
+  --file ${GO_ROOT}/test/shell/Dockerfile \
+  --tag ${IMAGE_NAME} \
+  --push \
+  ${GO_ROOT}

--- a/clients/java-logger/scripts/build_app.sh
+++ b/clients/java-logger/scripts/build_app.sh
@@ -40,5 +40,8 @@ fi
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
 IMAGE_NAME=${REPO}/${APP_NAME}:${TAG}
 
-docker build -f ${DOCKER_FILE} -t ${IMAGE_NAME} ${ROOT}/../..
-docker push ${IMAGE_NAME}
+docker buildx build \
+  --file ${DOCKER_FILE} \
+  --tag ${IMAGE_NAME} \
+  --push \
+  ${ROOT}/../..

--- a/clients/java-logger/shell/README.md
+++ b/clients/java-logger/shell/README.md
@@ -21,15 +21,23 @@ The main goal of this "shell" app is to provide the wrapper app that imports the
 #### Steps:
 
 1.  Clean the workspace and build the package from the project directory (where `pom.xml` is located):
+
     ```sh
     mvn clean package
     ```
+
 1.  Package into a container and push the container to Artifact Registry:
+
     ```sh
-    docker build -t ${REPO_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/logging-shell . && \
-    docker push ${REPO_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/logging-shell
+    docker buildx build \
+      --file "server_app.dockerfile" \
+      --tag "${REPO_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/logging-shell" \
+      --push \
+      .
     ```
+
 1.  Deploy to Cloud Run:
+
     ```sh
     gcloud run deploy ${CLOUD_RUN_SERVICE_NAME} \
     --image=${REPO_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/logging-shell \
@@ -38,11 +46,14 @@ The main goal of this "shell" app is to provide the wrapper app that imports the
     --project=${PROJECT_ID} \
     --quiet
     ```
+
 1.  Create a log by triggering the deployed service:
+
     ```sh
     curl -H "Authorization: Bearer $(gcloud auth print-identity-token )" \
     "${SERVICE_URL_RETURNED_IN_PREVIOUS_STEP}?trace_id=${ID_STRING}"
     ```
+
 1.  Audit log should appear in Logs Explorer in Cloud Console with `lumberjack_trace_id` as `${ID_STRING}` from previous step.
 
 #### Notes:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/abcxyz/lumberjack
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/bigquery v1.32.0

--- a/scripts/build_server.sh
+++ b/scripts/build_server.sh
@@ -27,9 +27,8 @@ if [ -z "${REPO:-}" ]; then
   echo "✋ Missing REPO!" >&2
 fi
 
-docker build \
+docker buildx build \
   --file="$(dirname "$0")/server.dockerfile" \
   --tag="${REPO}/lumberjack-server:${TAG}" \
+  --push \
   ${ROOT}
-
-docker push "${REPO}/lumberjack-server:${TAG}"


### PR DESCRIPTION
This commit updates the require module versions to Go 1.19 so we can take advantage of some of the faster compile times. It also updates the Dockerfiles to support multi-arch builds, if we ever wanted to provide arm64 or other platform-specific containers.