### PR TITLE
chore: update cleanup workflow to clean up images in the new location

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -76,7 +76,9 @@ jobs:
         with:
           args: >-
             -repo=us-docker.pkg.dev/lumberjack-dev-infra/images/lumberjack-server
-            -repo=us-docker.pkg.dev/github-ci-server/images/lumberjack-server
-            -repo=us-docker.pkg.dev/github-ci-app-0/images/test-app
+            -repo=us-docker.pkg.dev/lumberjack-dev-infra/images/ljc-go-grpc
+            -repo=us-docker.pkg.dev/lumberjack-dev-infra/images/ljc-go-http
+            -repo=us-docker.pkg.dev/lumberjack-dev-infra/images/ljc-java-grpc
+            -repo=us-docker.pkg.dev/lumberjack-dev-infra/images/ljc-java-http
             -grace=336h
-            -tag-filter-any=(?i)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
+            -tag-filter-any=(?i)[0-9a-f]{40}

--- a/terraform/modules/e2e/variables.tf
+++ b/terraform/modules/e2e/variables.tf
@@ -58,12 +58,6 @@ variable "server_image" {
   description = "The server container image."
 }
 
-variable "renew_random_tag" {
-  type        = bool
-  default     = false
-  description = "Whether to renew a random tag. If set a new random tag will be assigned and trigger a new build."
-}
-
 variable "registry_location" {
   type        = string
   default     = "us"


### PR DESCRIPTION
Follow up of https://github.com/abcxyz/lumberjack/pull/322
Now all the CI images are stored in the same registry with the commit being the tag (40 characters long).