### PR TITLE
chore: add goreleaser and use it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - name: 'Build the main server container and push to the registry with goreleaser'
         uses: 'goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757' # ratchet:goreleaser/goreleaser-action@v3
         with:
-          version: 'v3.2.0' # Manually pinned
+          version: 'v1.12.3' # Manually pinned
           args: 'release -f .goreleaser.docker.yaml --rm-dist'
 
   # Build the 4 integration test client variants, go-grpc, go-http, java-grpc and java-http

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         uses: 'goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757' # ratchet:goreleaser/goreleaser-action@v3
         with:
           version: 'v1.12.3' # Manually pinned
-          args: 'release -f .goreleaser.docker.yaml --rm-dist'
+          args: 'release -f .goreleaser.docker.yaml --rm-dist --skip-validate'
 
   # Build the 4 integration test client variants, go-grpc, go-http, java-grpc and java-http
   build-go-grpc-client:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
       # goreleaser requires a tag to publish images to container registry.
       # We create a local tag to make it happy.
       - run: |-
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git tag -f -a v0.0.0-ci -m "CI run"
       - name: 'Build the main server container and push to the registry with goreleaser'
         uses: 'goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757' # ratchet:goreleaser/goreleaser-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ on:
   workflow_dispatch:
 
 env:
-  docker_registry: 'us-docker.pkg.dev'
-  docker_tag: '${{ github.sha }}'
-  docker_repo: 'us-docker.pkg.dev/lumberjack-dev-infra/images'
-  wif_provider: 'projects/638387980668/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
-  wif_service_account: 'gh-access-sa@lumberjack-dev-infra.iam.gserviceaccount.com'
-  server_project_id: 'github-ci-server'
-  client_project_id: 'github-ci-app-0'
-  bigquery_dataset_id: 'audit_logs.audit_abcxyz_data_access'
+  DOCKER_REGISTRY: 'us-docker.pkg.dev'
+  DOCKER_TAG: '${{ github.sha }}'
+  DOCKER_REPO: 'us-docker.pkg.dev/lumberjack-dev-infra/images'
+  WIF_PROVIDER: 'projects/638387980668/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+  WIF_SERVICE_ACCOUNT: 'gh-access-sa@lumberjack-dev-infra.iam.gserviceaccount.com'
+  SERVER_PROJECT_ID: 'github-ci-server'
+  CLIENT_PROJECT_ID: 'github-ci-app-0'
+  BIGQUERY_DATASET_ID: 'audit_logs.audit_abcxyz_data_access'
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
@@ -84,27 +84,34 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      - uses: 'docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18' # ratchet:docker/setup-qemu-action@v2
       - name: 'Checkout'
         uses: 'actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b' # ratchet:actions/checkout@v3
+      - uses: 'actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f' # ratchet:actions/setup-go@v3
+        with:
+          go-version: '1.19'
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955' # ratchet:google-github-actions/auth@v0
         with:
-          workload_identity_provider: '${{ env.wif_provider }}'
-          service_account: '${{ env.wif_service_account }}'
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
           token_format: 'access_token'
       - name: 'Authenticate to Artifact Registry'
         uses: 'docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b' # ratchet:docker/login-action@v2
         with:
           username: 'oauth2accesstoken'
           password: '${{ steps.auth.outputs.access_token }}'
-          registry: '${{ env.docker_registry }}'
-      - name: 'Build the main server container and push to the registry'
-        uses: 'docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94' # ratchet:docker/build-push-action@v3
+          registry: '${{ env.DOCKER_REGISTRY }}'
+      # goreleaser requires a tag to publish images to container registry.
+      # We create a local tag to make it happy.
+      - run: |-
+          git tag -f -a v0.0.0-ci -m "CI run"
+      - name: 'Build the main server container and push to the registry with goreleaser'
+        uses: 'goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757' # ratchet:goreleaser/goreleaser-action@v3
         with:
-          push: true
-          tags: '${{ env.docker_repo }}/lumberjack-server:${{ env.docker_tag }}'
-          file: 'scripts/server.dockerfile'
+          version: 'v3.2.0' # Manually pinned
+          args: 'release -f .goreleaser.docker.yaml --rm-dist'
 
   # Build the 4 integration test client variants, go-grpc, go-http, java-grpc and java-http
   build-go-grpc-client:
@@ -127,20 +134,20 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955' # ratchet:google-github-actions/auth@v0
         with:
-          workload_identity_provider: '${{ env.wif_provider }}'
-          service_account: '${{ env.wif_service_account }}'
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
           token_format: 'access_token'
       - name: 'Authenticate to Artifact Registry'
         uses: 'docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b' # ratchet:docker/login-action@v2
         with:
           username: 'oauth2accesstoken'
           password: '${{ steps.auth.outputs.access_token }}'
-          registry: '${{ env.docker_registry }}'
+          registry: '${{ env.DOCKER_REGISTRY }}'
       - name: 'Build the integration test server container and push to the registry'
         uses: 'docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94' # ratchet:docker/build-push-action@v3
         with:
           push: true
-          tags: '${{ env.docker_repo }}/${{env.prefix}}-${{env.lang}}-${{env.type}}:${{env.docker_tag}}'
+          tags: '${{ env.DOCKER_REPO }}/${{env.prefix}}-${{env.lang}}-${{env.type}}:${{env.DOCKER_TAG}}'
           file: '${{ env.file }}'
           context: '${{ env.run_from }}'
 
@@ -164,20 +171,20 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955' # ratchet:google-github-actions/auth@v0
         with:
-          workload_identity_provider: '${{ env.wif_provider }}'
-          service_account: '${{ env.wif_service_account }}'
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
           token_format: 'access_token'
       - name: 'Authenticate to Artifact Registry'
         uses: 'docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b' # ratchet:docker/login-action@v2
         with:
           username: 'oauth2accesstoken'
           password: '${{ steps.auth.outputs.access_token }}'
-          registry: '${{ env.docker_registry }}'
+          registry: '${{ env.DOCKER_REGISTRY }}'
       - name: 'Build the integration test server container and push to the registry'
         uses: 'docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94' # ratchet:docker/build-push-action@v3
         with:
           push: true
-          tags: '${{ env.docker_repo }}/${{env.prefix}}-${{env.lang}}-${{env.type}}:${{env.docker_tag}}'
+          tags: '${{ env.DOCKER_REPO }}/${{env.prefix}}-${{env.lang}}-${{env.type}}:${{env.DOCKER_TAG}}'
           file: '${{ env.file }}'
           context: '${{ env.run_from }}'
 
@@ -201,20 +208,20 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955' # ratchet:google-github-actions/auth@v0
         with:
-          workload_identity_provider: '${{ env.wif_provider }}'
-          service_account: '${{ env.wif_service_account }}'
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
           token_format: 'access_token'
       - name: 'Authenticate to Artifact Registry'
         uses: 'docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b' # ratchet:docker/login-action@v2
         with:
           username: 'oauth2accesstoken'
           password: '${{ steps.auth.outputs.access_token }}'
-          registry: '${{ env.docker_registry }}'
+          registry: '${{ env.DOCKER_REGISTRY }}'
       - name: 'Build the integration test server container and push to the registry'
         uses: 'docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94' # ratchet:docker/build-push-action@v3
         with:
           push: true
-          tags: '${{ env.docker_repo }}/${{env.prefix}}-${{env.lang}}-${{env.type}}:${{env.docker_tag}}'
+          tags: '${{ env.DOCKER_REPO }}/${{env.prefix}}-${{env.lang}}-${{env.type}}:${{env.DOCKER_TAG}}'
           file: '${{ env.file }}'
           context: '${{ env.run_from }}'
 
@@ -238,20 +245,20 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955' # ratchet:google-github-actions/auth@v0
         with:
-          workload_identity_provider: '${{ env.wif_provider }}'
-          service_account: '${{ env.wif_service_account }}'
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
           token_format: 'access_token'
       - name: 'Authenticate to Artifact Registry'
         uses: 'docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b' # ratchet:docker/login-action@v2
         with:
           username: 'oauth2accesstoken'
           password: '${{ steps.auth.outputs.access_token }}'
-          registry: '${{ env.docker_registry }}'
+          registry: '${{ env.DOCKER_REGISTRY }}'
       - name: 'Build the integration test server container and push to the registry'
         uses: 'docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94' # ratchet:docker/build-push-action@v3
         with:
           push: true
-          tags: '${{ env.docker_repo }}/${{env.prefix}}-${{env.lang}}-${{env.type}}:${{env.docker_tag}}'
+          tags: '${{ env.DOCKER_REPO }}/${{env.prefix}}-${{env.lang}}-${{env.type}}:${{env.DOCKER_TAG}}'
           file: '${{ env.file }}'
           context: '${{ env.run_from }}'
 
@@ -284,8 +291,8 @@ jobs:
         name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955' # ratchet:goe-github-actions/auth@v0
         with:
-          workload_identity_provider: '${{ env.wif_provider }}'
-          service_account: '${{ env.wif_service_account }}'
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
           token_format: 'access_token'
 
       # TODO: Workload Identity doesn't work with GCS Provider.
@@ -300,17 +307,17 @@ jobs:
           terraform_wrapper: false
       - name: 'Write tfvars file'
         env:
-          client_images: '\{\"ljc-go-grpc\":\"${{env.docker_repo}}/ljc-go-grpc:${{env.docker_tag}}\",\"ljc-go-http\":\"${{env.docker_repo}}/ljc-go-http:${{env.docker_tag}}\",\"ljc-java-grpc\":\"${{env.docker_repo}}/ljc-java-grpc:${{env.docker_tag}}\",\"ljc-java-http\":\"${{env.docker_repo}}/ljc-java-http:${{env.docker_tag}}\"\}'
-          server_image: '${{env.docker_repo}}/lumberjack-server:${{env.docker_tag}}'
+          client_images: '\{\"ljc-go-grpc\":\"${{env.DOCKER_REPO}}/ljc-go-grpc:${{env.DOCKER_TAG}}\",\"ljc-go-http\":\"${{env.DOCKER_REPO}}/ljc-go-http:${{env.DOCKER_TAG}}\",\"ljc-java-grpc\":\"${{env.DOCKER_REPO}}/ljc-java-grpc:${{env.DOCKER_TAG}}\",\"ljc-java-http\":\"${{env.DOCKER_REPO}}/ljc-java-http:${{env.DOCKER_TAG}}\"\}'
+          server_image: '${{env.DOCKER_REPO}}/lumberjack-server:${{env.DOCKER_TAG}}'
         run: |-
             var_file=/tmp/ci.tfvars
 
             touch /tmp/ci.tfvars
-            echo commit_sha=\"${{ env.docker_tag }}\" >> ${var_file};
-            echo server_project_id=\"${{ env.server_project_id }}\" >> ${var_file};
+            echo commit_sha=\"${{ env.DOCKER_TAG }}\" >> ${var_file};
+            echo server_project_id=\"${{ env.SERVER_PROJECT_ID }}\" >> ${var_file};
             echo server_image=\"${{ env.server_image }}\" >> ${var_file};
             echo server_service_name=\"lumberjack-server\" >> ${var_file};
-            echo client_project_id=\"${{ env.client_project_id }}\" >> ${var_file};
+            echo client_project_id=\"${{ env.CLIENT_PROJECT_ID }}\" >> ${var_file};
             echo client_images=${{ env.client_images }} >> ${var_file};
             echo >> ${var_file};
 
@@ -347,12 +354,12 @@ jobs:
       - name: 'Run tests'
         id: 'run-tests'
         run: |-
-          export ID_TOKEN="$(gcloud auth print-identity-token --impersonate-service-account=${{ env.wif_service_account }} --include-email)"
+          export ID_TOKEN="$(gcloud auth print-identity-token --impersonate-service-account=${{ env.WIF_SERVICE_ACCOUNT }} --include-email)"
 
           go test ./integration/testrunner \
             -id-token="${ID_TOKEN}" \
-            -project-id="${{ env.server_project_id }}" \
-            -dataset-query="${{ env.bigquery_dataset_id }}"
+            -project-id="${{ env.SERVER_PROJECT_ID }}" \
+            -dataset-query="${{ env.BIGQUERY_DATASET_ID }}"
 
       - name: 'Cleanup the infrastructure'
         id: 'tf_destroy'

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -81,4 +81,4 @@ jobs:
             -repo=us-docker.pkg.dev/lumberjack-dev-infra/images/ljc-java-grpc
             -repo=us-docker.pkg.dev/lumberjack-dev-infra/images/ljc-java-http
             -grace=336h
-            -tag-filter-any=(?i)[0-9a-f]{40}
+            -tag-filter-any=(?i)[0-9a-f]{40}(-amd64|-arm64)?

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ go.work
 ### Visual Studio Code IDEA ###
 .vscode
 coverage.out
+
+# Ignore goreleaser output
+dist/

--- a/.goreleaser.docker.yaml
+++ b/.goreleaser.docker.yaml
@@ -19,7 +19,7 @@ env:
   - 'GOPROXY=https://proxy.golang.org,direct'
   # Allow override the container registry.
   # Default to the JVS CI container registry.
-  - REGISTRY={{ if index .Env "CONTAINER_REGISTRY"  }}{{ .Env.CONTAINER_REGISTRY }}{{ else }}us-docker.pkg.dev/lumberjack-dev-infra/images{{ end }}
+  - REGISTRY={{ if index .Env "DOCKER_REPO"  }}{{ .Env.DOCKER_REPO }}{{ else }}us-docker.pkg.dev/lumberjack-dev-infra/images{{ end }}
 
 before:
   hooks:
@@ -59,7 +59,7 @@ dockers:
     goos: 'linux'
     goarch: 'amd64'
     image_templates:
-      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "TAG_OVERRIDE"  }}{{ .Env.TAG_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}-amd64'
+      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "DOCKER_TAG"  }}{{ .Env.DOCKER_TAG }}{{ else }}{{ .Version }}{{ end }}-amd64'
     build_flag_templates:
       - '--platform=linux/amd64'
       - '--pull'
@@ -78,7 +78,7 @@ dockers:
     goos: 'linux'
     goarch: 'arm64'
     image_templates:
-      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "TAG_OVERRIDE"  }}{{ .Env.TAG_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}-arm64'
+      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "DOCKER_TAG"  }}{{ .Env.DOCKER_TAG }}{{ else }}{{ .Version }}{{ end }}-arm64'
     build_flag_templates:
       - '--platform=linux/arm64'
       - '--pull'
@@ -94,10 +94,10 @@ dockers:
 
 docker_manifests:
   -
-    name_template: '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "TAG_OVERRIDE"  }}{{ .Env.TAG_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}'
+    name_template: '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "DOCKER_TAG"  }}{{ .Env.DOCKER_TAG }}{{ else }}{{ .Version }}{{ end }}'
     image_templates:
-      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "TAG_OVERRIDE"  }}{{ .Env.TAG_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}-amd64'
-      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "TAG_OVERRIDE"  }}{{ .Env.TAG_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}-arm64'
+      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "DOCKER_TAG"  }}{{ .Env.DOCKER_TAG }}{{ else }}{{ .Version }}{{ end }}-amd64'
+      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "DOCKER_TAG"  }}{{ .Env.DOCKER_TAG }}{{ else }}{{ .Version }}{{ end }}-arm64'
 
 
 # TODO(#144): Follow up on sign.

--- a/.goreleaser.docker.yaml
+++ b/.goreleaser.docker.yaml
@@ -1,0 +1,108 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env:
+  # Global env vars for Go build.
+  - 'CGO_ENABLED=0'
+  - 'GO111MODULE=on'
+  - 'GOPROXY=https://proxy.golang.org,direct'
+  # Allow override the container registry.
+  # Default to the JVS CI container registry.
+  - REGISTRY={{ if index .Env "CONTAINER_REGISTRY"  }}{{ .Env.CONTAINER_REGISTRY }}{{ else }}us-docker.pkg.dev/lumberjack-dev-infra/images{{ end }}
+
+before:
+  hooks:
+    - go mod tidy
+
+# Duplicate the build from .goreleaser.yaml.
+builds:
+  -
+    id: server
+    main: ./cmd/server
+    binary: server
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - '-a'
+      - '-trimpath'
+    ldflags:
+      - '-s'
+      - '-w'
+      - '-X={{ .ModulePath }}/internal/version.Name=lumberjack-server'
+      - '-X={{ .ModulePath }}/internal/version.Version={{ .Version }}'
+      - '-X={{ .ModulePath }}/internal/version.Commit={{ .Commit }}'
+      - '-extldflags=-static'
+    goos:
+      - 'darwin'
+      - 'linux'
+      - 'windows'
+    goarch:
+      - 'amd64'
+      - 'arm64'
+
+
+dockers:
+  -
+    ids:
+    - server
+    use: 'buildx'
+    goos: 'linux'
+    goarch: 'amd64'
+    image_templates:
+      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "TAG_OVERRIDE"  }}{{ .Env.TAG_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}-amd64'
+    build_flag_templates:
+      - '--platform=linux/amd64'
+      - '--pull'
+      - '--label=org.opencontainers.image.created={{ .CommitTimestamp }}'
+      - '--label=org.opencontainers.image.description=Lumberjack server is an audit log ingestion service.'
+      - '--label=org.opencontainers.image.licenses=Apache-2.0'
+      - '--label=org.opencontainers.image.name=lumberjack-server'
+      - '--label=org.opencontainers.image.revision={{ .FullCommit }}'
+      - '--label=org.opencontainers.image.source={{ .GitURL }}'
+      - '--label=org.opencontainers.image.title=lumberjack-server'
+      - '--label=org.opencontainers.image.version={{ .Version }}'
+  -
+    ids:
+    - server
+    use: 'buildx'
+    goos: 'linux'
+    goarch: 'arm64'
+    image_templates:
+      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "TAG_OVERRIDE"  }}{{ .Env.TAG_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}-arm64'
+    build_flag_templates:
+      - '--platform=linux/arm64'
+      - '--pull'
+      - '--label=org.opencontainers.image.created={{ .CommitTimestamp }}'
+      - '--label=org.opencontainers.image.description=Lumberjack server is an audit log ingestion service.'
+      - '--label=org.opencontainers.image.licenses=Apache-2.0'
+      - '--label=org.opencontainers.image.name=lumberjack-server'
+      - '--label=org.opencontainers.image.revision={{ .FullCommit }}'
+      - '--label=org.opencontainers.image.source={{ .GitURL }}'
+      - '--label=org.opencontainers.image.title=lumberjack-server'
+      - '--label=org.opencontainers.image.version={{ .Version }}'
+
+
+docker_manifests:
+  -
+    name_template: '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "TAG_OVERRIDE"  }}{{ .Env.TAG_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}'
+    image_templates:
+      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "TAG_OVERRIDE"  }}{{ .Env.TAG_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}-amd64'
+      - '{{ .Env.REGISTRY }}/lumberjack-server:{{ if index .Env "TAG_OVERRIDE"  }}{{ .Env.TAG_OVERRIDE }}{{ else }}{{ .Version }}{{ end }}-arm64'
+
+
+# TODO(#144): Follow up on sign.
+
+
+# Disable SCM release we only want docker release here.
+release:
+  disable: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,73 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env:
+  # Global env vars for Go build.
+  - 'CGO_ENABLED=0'
+  - 'GO111MODULE=on'
+  - 'GOPROXY=https://proxy.golang.org,direct'
+
+before:
+  hooks:
+    - go mod tidy
+
+# Duplicate the builds to .goreleaser.docker.yaml
+builds:
+  -
+    id: server
+    main: ./cmd/server
+    binary: server
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - '-a'
+      - '-trimpath'
+    ldflags:
+      - '-s'
+      - '-w'
+      - '-X={{ .ModulePath }}/internal/version.Name=lumberjack-server'
+      - '-X={{ .ModulePath }}/internal/version.Version={{ .Version }}'
+      - '-X={{ .ModulePath }}/internal/version.Commit={{ .Commit }}'
+      - '-extldflags=-static'
+    goos:
+      - 'darwin'
+      - 'linux'
+      - 'windows'
+    goarch:
+      - 'amd64'
+      - 'arm64'
+
+
+archives:
+  - format: 'tar.gz'
+    name_template: 'lumberjack_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    format_overrides:
+      - goos: 'windows'
+        format: 'zip'
+
+
+checksum:
+  name_template: 'lumberjack_{{ .Version }}_SHA512SUMS'
+  algorithm: 'sha512'
+
+
+changelog:
+  use: github
+  sort: asc
+
+# TODO(#144): Follow up on sign.
+
+# Release to github.
+release:
+  draft: false
+  mode: replace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use distroless for ca certs.
+FROM gcr.io/distroless/static AS distroless
+
+
+# Use a scratch image to host our binary.
+FROM scratch
+COPY --from=distroless /etc/passwd /etc/passwd
+COPY --from=distroless /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+COPY server /server
+
+USER nobody
+
+# Run the web service on container startup.
+ENV PORT 8080
+ENTRYPOINT ["/server"]

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,16 +14,36 @@ See sample log sinks in Terraform for application-level audit logs in
 `google_logging_project_sink` resources
 [here](../terraform/modules/server-sink/main.tf).
 
-In case you want all your _cloud_ audit logs to end up in the same log storage,
+In case you want all your *cloud* audit logs to end up in the same log storage,
 find similar log sinks in `google_logging_project_sink` resources
 [here](../terraform/modules/cal-source-project/main.tf).
 
 ## (Optional) Ingestion Service
 
-Build the server with [Dockerfile](../scripts/server.dockerfile). Where you run
-the ingestion server doesn't matter as long as it's accessible by the
-applications. See [sample deployment](../terraform/modules/server-service/) with
-Cloud Run in Terraform.
+To build the ingestion service:
+
+```sh
+# By default we use JVS CI container registry for the images.
+# To override, set the following env var.
+# DOCKER_REPO=us-docker.pkg.dev/my-project/images
+
+# goreleaser expects a "clean" repo to release so commit any local changes if
+# needed.
+git add . && git commit -m "local changes"
+
+# goreleaser expects a tag.
+# The tag must be a semantic version https://semver.org/
+git tag -f -a v0.0.0-$(git rev-parse --short HEAD)
+
+# Use goreleaser to build the images.
+# It should in the end push all the images to the given container registry.
+# All the images will be tagged with the git tag given earlier.
+goreleaser release -f .goreleaser.docker.yaml --rm-dist
+```
+
+Where you run the ingestion server doesn't matter as long as it's accessible by
+the applications. See [sample deployment](../terraform/modules/server-service/)
+with Cloud Run in Terraform.
 
 ## E2E
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,7 +23,7 @@ find similar log sinks in `google_logging_project_sink` resources
 To build the ingestion service:
 
 ```sh
-# By default we use JVS CI container registry for the images.
+# By default we use Lumberjack CI container registry for the images.
 # To override, set the following env var.
 # DOCKER_REPO=us-docker.pkg.dev/my-project/images
 


### PR DESCRIPTION
Fix: https://github.com/abcxyz/lumberjack/issues/286

We use goreleaser in CI to publish the ingestion service image so we can keep it close to how we will actually release.
It doesn't make sense to use goreleaser for CI test clients image build since we don't really release those images.