### PR TITLE
fix: update java client shell app readme

### DIFF
--- a/clients/java-logger/shell/README.md
+++ b/clients/java-logger/shell/README.md
@@ -20,17 +20,12 @@ The main goal of this "shell" app is to provide the wrapper app that imports the
 
 #### Steps:
 
-1.  Clean the workspace and build the package from the project directory (where `pom.xml` is located):
-
-    ```sh
-    mvn clean package
-    ```
-
-1.  Package into a container and push the container to Artifact Registry:
+1.  Package into a container and push the container to Artifact Registry from
+    the root of repository:
 
     ```sh
     docker buildx build \
-      --file "server_app.dockerfile" \
+      --file "clients/java-logger/scripts/shell_app.dockerfile" \
       --tag "${REPO_REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/logging-shell" \
       --push \
       .


### PR DESCRIPTION
Removed step 1 as the [dockerfile already does it](https://github.com/abcxyz/lumberjack/blob/59b38a871f55f057a89bc97d703d0e5ca2f787a6/clients/java-logger/scripts/shell_app.dockerfile#L3) 

Was able to deploy the service with `--update-env-vars=AUDIT_CLIENT_BACKEND_CLOUDLOGGING_PROJECT=suhongq-test-project` (requires https://github.com/abcxyz/lumberjack/pull/334 )and log the request.
