### PR TITLE
fix: use official JVS release to avoid jitpack flakiness

### DIFF
--- a/clients/java-logger/library/pom.xml
+++ b/clients/java-logger/library/pom.xml
@@ -131,8 +131,8 @@
       <version>31.1-jre</version>
     </dependency>
     <dependency>
-      <groupId>com.github.abcxyz</groupId>
-      <artifactId>jvs</artifactId>
+      <groupId>com.abcxyz.jvs</groupId>
+      <artifactId>jvs-client</artifactId>
       <version>0.0.1</version>
     </dependency>
   </dependencies>

--- a/clients/java-logger/library/pom.xml
+++ b/clients/java-logger/library/pom.xml
@@ -30,11 +30,7 @@
   </properties>
 
   <repositories>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-    <!-- For releasing package to Artifact Registry -->
+    <!-- For connecting to Artifact Registry -->
     <repository>
       <id>artifact-registry</id>
       <url>artifactregistry://us-maven.pkg.dev/abcxyz-artifacts/maven-repo</url>
@@ -137,7 +133,7 @@
     <dependency>
       <groupId>com.github.abcxyz</groupId>
       <artifactId>jvs</artifactId>
-      <version>051e121fe9e79baf2ffc4a70bbcd903035768acc</version>
+      <version>0.0.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
We have seen such errors in CI quite often: https://github.com/abcxyz/lumberjack/actions/runs/3431657807/jobs/5720044555
It looks like caused by jitpack pulling JVS at the given commit which in turn tried to pull in indirect dependencies.