### PR TITLE
fix: make artifact registry Maven wagon happy in unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      # Technically the our Artifact Registry Maven repo is public and we don't need this.
+      # Technically our Artifact Registry Maven repo is public and we don't need this step.
       # But the Artifact Registry wagon will keep retrying the authentication and blocking
       # the unit test for a long time (likely a bug). As a result, we add this step to make
       # the wagon happy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           workload_identity_provider: '${{ env.WIF_PROVIDER }}'
           service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+          create_credentials_file: false
           # The Artifact Registry maven wagon looks for Google Application Default Credentials.
           # https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools
       - name: Run tests with Maven

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
 
   java_test:
     runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: 'actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8' # ratchet:actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,17 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      # Technically the our Artifact Registry Maven repo is public and we don't need this.
+      # But the Artifact Registry wagon will keep retrying the authentication and blocking
+      # the unit test for a long time (likely a bug). As a result, we add this step to make
+      # the wagon happy.
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@c4799db9111fba4461e9f9da8732e5057b394f72' # ratchet:google-github-actions/auth@v0
+        with:
+          workload_identity_provider: '${{ env.WIF_PROVIDER }}'
+          service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
+          # The Artifact Registry maven wagon looks for Google Application Default Credentials.
+          # https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools
       - name: Run tests with Maven
         run: |-
           mvn clean test --no-transfer-progress -f clients/java-logger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
         with:
           workload_identity_provider: '${{ env.WIF_PROVIDER }}'
           service_account: '${{ env.WIF_SERVICE_ACCOUNT }}'
-          create_credentials_file: false
           # The Artifact Registry maven wagon looks for Google Application Default Credentials.
           # https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools
       - name: Run tests with Maven

--- a/clients/java-logger/library/pom.xml
+++ b/clients/java-logger/library/pom.xml
@@ -203,7 +203,7 @@
       <extension>
         <groupId>com.google.cloud.artifactregistry</groupId>
         <artifactId>artifactregistry-maven-wagon</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </extension>
     </extensions>
   </build>


### PR DESCRIPTION
Here is the longer story.

In order to publish Java client to Artifact Registry, we follow the steps here https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools to add the AR maven wagon to the `pom.xml`. The AR maven repo is publicly _readable_. We did this for _both_ Lumberjack and JVS Java client.

Lumberjack Java client depends on the JVS client. Because our maven repo is publicly readable, we _should not_ need any authentication with AR to pull the JVS client and run the unit test. However as long as the AR maven wagon is added, it will try to get the gcloud cred and authenticate with AR no matter whether the repo itself is public or not (this is likely a bug of AR maven wagon). And it will fail in the CI Java test job because gcloud cred is not available.

This PR adds the auth step to the Java test job to make the wagon happy. For a real user, this is not necessary. One just needs to use the following in their `pom.xml` rather than the full set of AR wagon setup:

```xml
  <repositories>
    <repository>
      <id>artifact-registry</id>
      <url>https://us-maven.pkg.dev/abcxyz-artifacts/maven-repo</url>
  </repositories>
```

The major difference is in the `<url>` - instead of using `artifactregistry://`, one needs to use `https://`. This is _not_ clearly documented in AR doc.

---

**Update**: It turns out I also need to update the wagon version otherwise it is still somewhat slow.