### PR TITLE
fix: jvs config bug

### DIFF
--- a/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/config/AuditLoggingConfiguration.java
+++ b/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/config/AuditLoggingConfiguration.java
@@ -47,7 +47,7 @@ public class AuditLoggingConfiguration {
   private SecurityContext securityContext;
 
   @JsonProperty("justification")
-  private Justification justification;
+  private Justification justification = new Justification();
 
   @JsonProperty(value = "breakglass_allowed")
   private boolean breakglassAllowed = false;

--- a/clients/java-logger/library/src/test/java/com/abcxyz/lumberjack/auditlogclient/config/AuditLoggingConfigurationTest.java
+++ b/clients/java-logger/library/src/test/java/com/abcxyz/lumberjack/auditlogclient/config/AuditLoggingConfigurationTest.java
@@ -17,6 +17,7 @@
 package com.abcxyz.lumberjack.auditlogclient.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.abcxyz.lumberjack.auditlogclient.modules.AuditLoggingConfigurationModule;
 import com.abcxyz.lumberjack.auditlogclient.modules.AuditLoggingModule;
@@ -42,7 +43,8 @@ public class AuditLoggingConfigurationTest {
     assertThat(config.getConditions()).isNull();
     assertThat(config.getRules().size()).isEqualTo(1);
     assertThat(config.getLogMode()).isEqualTo(LogMode.LOG_MODE_UNSPECIFIED);
-    assertThat(config.getJustification()).isNull();
+    assertThat(config.getJustification().getPublicKeysEndpoint()).isNull();
+    assertFalse(config.getJustificaiton().isEnabled());
 
     assertThat(module.backendContext(config)).isEqualTo(expectedBackendContext);
     assertThat(module.filters(config)).isEqualTo(new Filters());
@@ -93,7 +95,8 @@ public class AuditLoggingConfigurationTest {
     assertThat(config.getFilters().getExcludes()).isEqualTo("*.exclude.example.com");
     assertThat(config.getRules().size()).isEqualTo(1);
     assertThat(config.getLogMode()).isEqualTo(LogMode.LOG_MODE_UNSPECIFIED);
-    assertThat(config.getJustification()).isNull();
+    assertThat(config.getJustification().getPublicKeysEndpoint()).isNull();
+    assertFalse(config.getJustificaiton().isEnabled());
 
     assertThat(module.backendContext(config)).isEqualTo(expectedBackendContext);
   }


### PR DESCRIPTION
Current java client does not load jvs related env variables if justification is not in the config file. This change should fix this bug.

We should test all env variables if they are working as expected in this [task](https://github.com/abcxyz/lumberjack/issues/203).