### PR TITLE
Upgrade protoc and proto-gen-java

### DIFF
--- a/clients/java-logger/grpc-test-app/pom.xml
+++ b/clients/java-logger/grpc-test-app/pom.xml
@@ -13,6 +13,17 @@
   <groupId>com.abcxyz.lumberjack</groupId>
   <version>0.0.1</version>
 
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <java.version>11</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <lumberjack.basedir>../../..</lumberjack.basedir>
+    <protobuf.version>3.21.7</protobuf.version>
+    <protoc.version>3.21.12</protoc.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -24,16 +35,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <java.version>11</java.version>
-    <lumberjack.basedir>../../..</lumberjack.basedir>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <protobuf.version>3.19.1</protobuf.version>
-    <protoc.version>3.19.1</protoc.version>
-  </properties>
 
   <dependencies>
     <dependency>
@@ -55,7 +56,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.21.7</version>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
@@ -202,6 +203,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <protocVersion>${protoc.version}</protocVersion>
               <includeStdTypes>true</includeStdTypes>
               <inputDirectories>
                 <include>${lumberjack.basedir}/internal/protos/talker</include>
@@ -213,8 +215,7 @@
                 </outputTarget>
                 <outputTarget>
                   <type>grpc-java</type>
-                  <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.41.0
-                  </pluginArtifact>
+                  <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.50.1</pluginArtifact>
                 </outputTarget>
               </outputTargets>
             </configuration>
@@ -225,6 +226,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <protocVersion>${protoc.version}</protocVersion>
               <includeStdTypes>true</includeStdTypes>
               <includeDirectories>
                 <include>${lumberjack.basedir}/internal/protos/talker</include>

--- a/clients/java-logger/library/pom.xml
+++ b/clients/java-logger/library/pom.xml
@@ -22,11 +22,15 @@
 
   <properties>
     <revision>0.0.1</revision>
+
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <java.version>11</java.version>
-    <lumberjack.basedir>../../..</lumberjack.basedir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <lumberjack.basedir>../../..</lumberjack.basedir>
+    <protobuf.version>3.21.7</protobuf.version>
+    <protoc.version>3.21.12</protoc.version>
   </properties>
 
   <repositories>
@@ -63,7 +67,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.21.7</version>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
@@ -174,6 +178,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <protocVersion>${protoc.version}</protocVersion>
               <includeStdTypes>true</includeStdTypes>
               <includeDirectories>
                 <include>${lumberjack.basedir}/internal/protos/talker</include>
@@ -189,8 +194,7 @@
                 </outputTarget>
                 <outputTarget>
                   <type>grpc-java</type>
-                  <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.41.0
-                  </pluginArtifact>
+                  <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.50.1</pluginArtifact>
                 </outputTarget>
               </outputTargets>
             </configuration>

--- a/clients/java-logger/shell/pom.xml
+++ b/clients/java-logger/shell/pom.xml
@@ -12,10 +12,18 @@
   <artifactId>audit-client-shell</artifactId>
   <groupId>com.abcxyz.lumberjack</groupId>
   <version>0.0.1</version>
+
   <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <java.version>11</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
     <lumberjack.basedir>../../..</lumberjack.basedir>
+    <protobuf.version>3.21.7</protobuf.version>
+    <protoc.version>3.21.12</protoc.version>
   </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -90,6 +98,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <protocVersion>${protoc.version}</protocVersion>
               <includeStdTypes>true</includeStdTypes>
               <includeDirectories>
                 <include>${lumberjack.basedir}/internal/protos/talker</include>


### PR DESCRIPTION
This fixes an issue where it's not possible to run on an M1 Mac because amd binaries are not available on the older versions.