### PR TITLE
Move Shell and GRPC test Java apps to Java 17.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
     uses: 'abcxyz/pkg/.github/workflows/java-lint.yml@main' # ratchet:exclude
     with:
       directory: 'clients/java-logger'
-      java_version: '11'
+      java_version: '17'
+      java_distribution: 'temurin'
 
   # Unit tests - java, go
   go_test:
@@ -56,11 +57,11 @@ jobs:
       id-token: 'write'
     steps:
       - uses: 'actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b' # ratchet:actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b # ratchet:actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
       # Technically our Artifact Registry Maven repo is public and we don't need this step.
       # But the Artifact Registry wagon will keep retrying the authentication and blocking
       # the unit test for a long time (likely a bug). As a result, we add this step to make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     with:
       directory: 'clients/java-logger'
       java_version: '17'
-      java_distribution: 'temurin'
+      java_distribution: 'corretto'
 
   # Unit tests - java, go
   go_test:
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b # ratchet:actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'temurin'
+          distribution: 'corretto'
       # Technically our Artifact Registry Maven repo is public and we don't need this step.
       # But the Artifact Registry wagon will keep retrying the authentication and blocking
       # the unit test for a long time (likely a bug). As a result, we add this step to make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b # ratchet:actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'temurin'
+          distribution: 'corretto'
 
       - uses: 'google-github-actions/auth@c4799db9111fba4461e9f9da8732e5057b394f72' # ratchet:google-github-actions/auth@v0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,8 @@ jobs:
 
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b # ratchet:actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
 
       - uses: 'google-github-actions/auth@c4799db9111fba4461e9f9da8732e5057b394f72' # ratchet:google-github-actions/auth@v0
         with:

--- a/clients/java-logger/grpc-test-app/pom.xml
+++ b/clients/java-logger/grpc-test-app/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <lumberjack.basedir>../../..</lumberjack.basedir>
-    <protobuf.version>3.21.7</protobuf.version>
+    <protobuf.version>3.21.12</protobuf.version>
     <protoc.version>3.21.12</protoc.version>
   </properties>
 

--- a/clients/java-logger/grpc-test-app/pom.xml
+++ b/clients/java-logger/grpc-test-app/pom.xml
@@ -14,9 +14,9 @@
   <version>0.0.1</version>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <java.version>11</java.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <lumberjack.basedir>../../..</lumberjack.basedir>

--- a/clients/java-logger/grpc-test-app/pom.xml
+++ b/clients/java-logger/grpc-test-app/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <lumberjack.basedir>../../..</lumberjack.basedir>
-    <protobuf.version>3.21.12</protobuf.version>
+    <protobuf.version>3.21.7</protobuf.version>
     <protoc.version>3.21.12</protoc.version>
   </properties>
 

--- a/clients/java-logger/scripts/server_app.dockerfile
+++ b/clients/java-logger/scripts/server_app.dockerfile
@@ -1,7 +1,7 @@
-FROM maven:3.8.3-openjdk-11 AS builder
+FROM maven:3.8.7-eclipse-temurin-17 AS builder
 COPY . /src
 RUN mvn clean package --no-transfer-progress -f /src/clients/java-logger/pom.xml
 
-FROM gcr.io/distroless/java-debian11:11
+FROM gcr.io/distroless/java17-debian11
 COPY --from=builder /src/clients/java-logger/grpc-test-app/target/grpc-test-app-0.0.1.jar server.jar
 CMD ["server.jar"]

--- a/clients/java-logger/scripts/server_app.dockerfile
+++ b/clients/java-logger/scripts/server_app.dockerfile
@@ -1,7 +1,7 @@
-FROM maven:3.8.7-amazoncorretto-17 AS builder
+FROM maven:3.8.3-openjdk-11 AS builder
 COPY . /src
 RUN mvn clean package --no-transfer-progress -f /src/clients/java-logger/pom.xml
 
-FROM gcr.io/distroless/java17-debian11
+FROM gcr.io/distroless/java-debian11:11
 COPY --from=builder /src/clients/java-logger/grpc-test-app/target/grpc-test-app-0.0.1.jar server.jar
 CMD ["server.jar"]

--- a/clients/java-logger/scripts/server_app.dockerfile
+++ b/clients/java-logger/scripts/server_app.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.7-eclipse-temurin-17 AS builder
+FROM maven:3.8.7-amazoncorretto-17 AS builder
 COPY . /src
 RUN mvn clean package --no-transfer-progress -f /src/clients/java-logger/pom.xml
 

--- a/clients/java-logger/scripts/server_app.dockerfile
+++ b/clients/java-logger/scripts/server_app.dockerfile
@@ -1,7 +1,7 @@
-FROM maven:3.8.3-openjdk-11 AS builder
+FROM maven:3.8.7-amazoncorretto-17 AS builder
 COPY . /src
 RUN mvn clean package --no-transfer-progress -f /src/clients/java-logger/pom.xml
 
-FROM gcr.io/distroless/java-debian11:11
+FROM gcr.io/distroless/java17-debian11
 COPY --from=builder /src/clients/java-logger/grpc-test-app/target/grpc-test-app-0.0.1.jar server.jar
 CMD ["server.jar"]

--- a/clients/java-logger/scripts/shell_app.dockerfile
+++ b/clients/java-logger/scripts/shell_app.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.7-eclipse-temurin-17 AS builder
+FROM maven:3.8.7-amazoncorretto-17 AS builder
 COPY . /src
 RUN mvn clean package --no-transfer-progress -f /src/clients/java-logger/pom.xml
 

--- a/clients/java-logger/scripts/shell_app.dockerfile
+++ b/clients/java-logger/scripts/shell_app.dockerfile
@@ -1,7 +1,7 @@
-FROM maven:3.8.3-openjdk-11 AS builder
+FROM maven:3.8.7-eclipse-temurin-17 AS builder
 COPY . /src
 RUN mvn clean package --no-transfer-progress -f /src/clients/java-logger/pom.xml
 
-FROM gcr.io/distroless/java-debian11:11
+FROM gcr.io/distroless/java17-debian11
 COPY --from=builder /src/clients/java-logger/shell/target/*.jar app.jar
 CMD ["app.jar"]

--- a/clients/java-logger/shell/pom.xml
+++ b/clients/java-logger/shell/pom.xml
@@ -14,9 +14,9 @@
   <version>0.0.1</version>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <java.version>11</java.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <lumberjack.basedir>../../..</lumberjack.basedir>

--- a/clients/java-logger/shell/pom.xml
+++ b/clients/java-logger/shell/pom.xml
@@ -20,7 +20,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <lumberjack.basedir>../../..</lumberjack.basedir>
-    <protobuf.version>3.21.7</protobuf.version>
     <protoc.version>3.21.12</protoc.version>
   </properties>
 


### PR DESCRIPTION
Per the note in https://github.com/actions/setup-java#supported-distributions, looks like `temurin` or `corretto` may be the right distribution to move to.