### PR TITLE
Use client context for options

### DIFF
--- a/clients/go/pkg/audit/client_test.go
+++ b/clients/go/pkg/audit/client_test.go
@@ -25,6 +25,7 @@ import (
 
 	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
+	"github.com/abcxyz/pkg/logging"
 	pkgtestutil "github.com/abcxyz/pkg/testutil"
 )
 
@@ -46,8 +47,9 @@ func (p testOrderProcessor) Process(_ context.Context, logReq *api.AuditLogReque
 func TestLog(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	tests := []struct {
+	ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
+
+	cases := []struct {
 		name          string
 		logReq        *api.AuditLogRequest
 		opts          []Option
@@ -168,12 +170,14 @@ func TestLog(t *testing.T) {
 			wantErrSubstr: "failed to execute backend",
 		},
 	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			c, err := NewClient(test.opts...)
+			c, err := NewClient(ctx, tc.opts...)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -183,12 +187,12 @@ func TestLog(t *testing.T) {
 					t.Errorf("failed to stop client: %v", err)
 				}
 			})
-			err = c.Log(ctx, test.logReq)
-			if diff := pkgtestutil.DiffErrString(err, test.wantErrSubstr); diff != "" {
-				t.Errorf("Log(%+v) got unexpected error substring: %v", test.logReq, diff)
+			err = c.Log(ctx, tc.logReq)
+			if diff := pkgtestutil.DiffErrString(err, tc.wantErrSubstr); diff != "" {
+				t.Errorf("Log(%+v) got unexpected error substring: %v", tc.logReq, diff)
 			}
-			if diff := cmp.Diff(test.wantLogReq, test.logReq, protocmp.Transform()); diff != "" {
-				t.Errorf("Process(%+v) got diff (-want, +got): %v", test.logReq, diff)
+			if diff := cmp.Diff(tc.wantLogReq, tc.logReq, protocmp.Transform()); diff != "" {
+				t.Errorf("Process(%+v) got diff (-want, +got): %v", tc.logReq, diff)
 			}
 		})
 	}
@@ -196,9 +200,10 @@ func TestLog(t *testing.T) {
 
 func TestHandleReturn_Client(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	tests := []struct {
+	ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
+
+	cases := []struct {
 		name    string
 		logMode api.AuditLogRequest_LogMode
 		err     error
@@ -222,11 +227,14 @@ func TestHandleReturn_Client(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	for _, tc := range tests {
+
+	for _, tc := range cases {
 		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			c, err := NewClient()
+
+			c, err := NewClient(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/clients/go/test/grpc-app/main.go
+++ b/clients/go/test/grpc-app/main.go
@@ -82,8 +82,7 @@ func realMain() (outErr error) {
 	if err != nil {
 		return fmt.Errorf("failed to create jvs client: %w", err)
 	}
-	interceptor, err := audit.NewInterceptor(
-		auditopt.InterceptorFromConfigFile(ctx, auditopt.DefaultConfigFilePath))
+	interceptor, err := audit.NewInterceptor(ctx, auditopt.InterceptorFromConfigFile(auditopt.DefaultConfigFilePath))
 	if err != nil {
 		return fmt.Errorf("failed to setup audit interceptor: %w", err)
 	}

--- a/clients/go/test/shell/main.go
+++ b/clients/go/test/shell/main.go
@@ -140,7 +140,7 @@ func main() {
 //   - listening to incoming requests in a goroutine
 func realMain(ctx context.Context) error {
 	// Create a ServeMux with a handler containing the audit client.
-	client, err := audit.NewClient(auditopt.FromConfigFile(ctx, ""))
+	client, err := audit.NewClient(ctx, auditopt.FromConfigFile(""))
 	if err != nil {
 		return fmt.Errorf("failed to init audit client: %w", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -77,7 +77,7 @@ func realMain(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	client, err := audit.NewClient(audit.WithBackend(cl))
+	client, err := audit.NewClient(ctx, audit.WithBackend(cl))
 	if err != nil {
 		return fmt.Errorf("failed to create audit client: %w", err)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -32,6 +32,7 @@ import (
 	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/audit"
 	"github.com/abcxyz/lumberjack/clients/go/pkg/testutil"
+	"github.com/abcxyz/pkg/logging"
 )
 
 type fakeLogProcessor struct {
@@ -56,6 +57,8 @@ func (p *fakeLogProcessor) Process(_ context.Context, logReq *api.AuditLogReques
 
 func TestAuditLogAgent_ProcessLog(t *testing.T) {
 	t.Parallel()
+
+	ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
 
 	cases := []struct {
 		name        string
@@ -121,7 +124,10 @@ func TestAuditLogAgent_ProcessLog(t *testing.T) {
 			s := grpc.NewServer()
 			defer s.Stop()
 
-			ac, err := audit.NewClient(audit.WithBackend(tc.p), audit.WithLogMode(api.AuditLogRequest_FAIL_CLOSE))
+			ac, err := audit.NewClient(ctx,
+				audit.WithBackend(tc.p),
+				audit.WithLogMode(api.AuditLogRequest_FAIL_CLOSE),
+			)
 			if err != nil {
 				t.Fatalf("Failed to create audit client: %v", err)
 			}


### PR DESCRIPTION
This changes the structure for options so that they use the context that is passed to the `NewClient` or other initialization call instead of using a context that was created specifically for the option. This ensures all options use the same context.