### PR TITLE
feat: added timestamp field validation in e2e and fixed missing timestamp bug in java src

### DIFF
--- a/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/processor/CloudLoggingProcessor.java
+++ b/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/processor/CloudLoggingProcessor.java
@@ -23,7 +23,6 @@ import com.abcxyz.lumberjack.v1alpha1.AuditLogRequestProto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.cloud.MonitoredResource;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingException;
@@ -47,7 +46,6 @@ import lombok.extern.java.Log;
 @Log
 @AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor = @__({@Inject}))
 public class CloudLoggingProcessor implements LogBackend {
-  private static final String MONITORED_RESOURCE_TYPE = "global";
   private final ObjectMapper mapper;
   private final Logging logging;
 
@@ -84,7 +82,6 @@ public class CloudLoggingProcessor implements LogBackend {
                   Instant.ofEpochSecond(
                       auditLogRequest.getTimestamp().getSeconds(),
                       auditLogRequest.getTimestamp().getNanos()))
-              .setResource(MonitoredResource.newBuilder(MONITORED_RESOURCE_TYPE).build())
               .build();
       logging.write(Collections.singleton(entry));
       return auditLogRequest;

--- a/clients/java-logger/shell/src/main/java/com/abcxyz/lumberjack/loggingshell/LoggingConfiguration.java
+++ b/clients/java-logger/shell/src/main/java/com/abcxyz/lumberjack/loggingshell/LoggingConfiguration.java
@@ -21,6 +21,7 @@ import com.abcxyz.lumberjack.auditlogclient.LoggingClientBuilder;
 import com.abcxyz.lumberjack.auditlogclient.modules.AuditLoggingModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import java.time.Clock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -32,5 +33,10 @@ public class LoggingConfiguration {
     Injector injector = Guice.createInjector(new AuditLoggingModule());
     LoggingClientBuilder builder = injector.getInstance(LoggingClientBuilder.class);
     return builder.withDefaultProcessors().build();
+  }
+
+  @Bean
+  Clock clock() {
+    return Clock.systemUTC();
   }
 }

--- a/clients/java-logger/shell/src/main/java/com/abcxyz/lumberjack/loggingshell/LoggingController.java
+++ b/clients/java-logger/shell/src/main/java/com/abcxyz/lumberjack/loggingshell/LoggingController.java
@@ -22,6 +22,9 @@ import com.abcxyz.lumberjack.v1alpha1.AuditLogRequest;
 import com.abcxyz.lumberjack.v1alpha1.AuditLogRequest.LogType;
 import com.google.cloud.audit.AuditLog;
 import com.google.cloud.audit.AuthenticationInfo;
+import com.google.protobuf.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -41,14 +44,19 @@ public class LoggingController {
 
   private final LoggingClient loggingClient;
 
+  private final Clock clock;
+
   @GetMapping
   @ResponseStatus(value = HttpStatus.OK)
   void loggingShell(
       @RequestParam(value = TRACE_ID_PARAMETER_KEY) String traceId,
       @RequestAttribute(TokenInterceptor.INTERCEPTOR_USER_EMAIL_KEY) String userEmail)
       throws LogProcessingException {
+    Instant now = clock.instant();
     AuditLogRequest record =
         AuditLogRequest.newBuilder()
+            .setTimestamp(
+                Timestamp.newBuilder().setSeconds(now.getEpochSecond()).setNanos(now.getNano()))
             .setPayload(
                 AuditLog.newBuilder()
                     .setServiceName(SERVICE_NAME)


### PR DESCRIPTION
part of #381 
1. added timestamp in java logging shell
2. not override `resource` field when generating logentry in java
3. added `timestamp` field validation