### PR TITLE
fix: apply log mode option when initiating go client

### DIFF
--- a/clients/go/apis/v1alpha1/auditlogutil.go
+++ b/clients/go/apis/v1alpha1/auditlogutil.go
@@ -14,8 +14,7 @@
 
 package v1alpha1
 
-// ShouldFailClose returns true only if FAIL_CLOSE is explicitly configured. On BEST_EFFORT or LOG_MODE_UNSPECIFIED
-// (the default) then return false.
+// ShouldFailClose returns whether we should fail close on errors.
 func ShouldFailClose(logMode AuditLogRequest_LogMode) bool {
 	return logMode == AuditLogRequest_FAIL_CLOSE
 }

--- a/clients/go/apis/v1alpha1/config.go
+++ b/clients/go/apis/v1alpha1/config.go
@@ -119,7 +119,7 @@ func (cfg *Config) SetDefault() {
 		cfg.Version = Version
 	}
 
-	// Default log mode to "fail close".
+	// Default empty and LOG_MODE_UNSPECIFIED log mode to FAIL_CLOSE.
 	if cfg.LogMode == "" || strings.ToUpper(cfg.LogMode) == AuditLogRequest_LOG_MODE_UNSPECIFIED.String() {
 		cfg.LogMode = AuditLogRequest_FAIL_CLOSE.String()
 	}

--- a/clients/go/pkg/auditopt/config.go
+++ b/clients/go/pkg/auditopt/config.go
@@ -69,12 +69,6 @@ func FromConfigFile(path string) audit.Option {
 // FromConfig creates an audit client option from the given configuration.
 func FromConfig(cfg *api.Config) audit.Option {
 	return func(ctx context.Context, c *audit.Client) error {
-		if cfg == nil {
-			return fmt.Errorf("nil config")
-		}
-		if err := cfg.Validate(); err != nil {
-			return fmt.Errorf("invalid configuration: %w", err)
-		}
 		return clientFromConfig(ctx, c, cfg)
 	}
 }
@@ -166,6 +160,13 @@ func interceptorFromConfigFile(path string, lookuper envconfig.Lookuper) audit.I
 }
 
 func clientFromConfig(ctx context.Context, c *audit.Client, cfg *api.Config) error {
+	if cfg == nil {
+		return fmt.Errorf("nil config")
+	}
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
 	opts := []audit.Option{audit.WithRuntimeInfo()}
 
 	withPrincipalFilter, err := principalFilterFromConfig(cfg)
@@ -184,6 +185,9 @@ func clientFromConfig(ctx context.Context, c *audit.Client, cfg *api.Config) err
 
 	withLabels := labelsFromConfig(ctx, cfg)
 	opts = append(opts, withLabels)
+
+	withLogMode := audit.WithLogMode(cfg.GetLogMode())
+	opts = append(opts, withLogMode)
 
 	if cfg.Justification != nil && cfg.Justification.Enabled {
 		withJustification, err := justificationFromConfig(ctx, cfg)

--- a/clients/go/pkg/auditopt/config_test.go
+++ b/clients/go/pkg/auditopt/config_test.go
@@ -86,10 +86,12 @@ backend:
 		wantErrSubstr string
 	}{
 		{
-			name:    "use_config_file_when_provided",
-			path:    path.Join(dir, "valid.yaml"),
-			req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
-			wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			name: "use_config_file_when_provided",
+			path: path.Join(dir, "valid.yaml"),
+			req:  testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			wantReq: testutil.NewRequest(
+				testutil.WithPrincipal("abc@project.iam.gserviceaccount.com"),
+				testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
 		},
 		{
 			name: "use_env_var_when_config_file_not_found",
@@ -98,9 +100,12 @@ backend:
 				"AUDIT_CLIENT_CONDITION_REGEX_PRINCIPAL_EXCLUDE":  "user@example.com$",
 				"AUDIT_CLIENT_BACKEND_REMOTE_INSECURE_ENABLED":    "true",
 				"AUDIT_CLIENT_BACKEND_REMOTE_IMPERSONATE_ACCOUNT": "example@test.iam.gserviceaccount.com",
+				"AUDIT_CLIENT_LOG_MODE":                           "BEST_EFFORT",
 			},
-			req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
-			wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			req: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			wantReq: testutil.NewRequest(
+				testutil.WithPrincipal("abc@project.iam.gserviceaccount.com"),
+				testutil.WithMode(api.AuditLogRequest_BEST_EFFORT)),
 		},
 		{
 			name: "use_defaults_when_config_file_not_found",
@@ -108,9 +113,12 @@ backend:
 			envs: map[string]string{
 				"AUDIT_CLIENT_BACKEND_REMOTE_INSECURE_ENABLED":    "true",
 				"AUDIT_CLIENT_BACKEND_REMOTE_IMPERSONATE_ACCOUNT": "example@test.iam.gserviceaccount.com",
+				"AUDIT_CLIENT_LOG_MODE":                           "LOG_MODE_UNSPECIFIED",
 			},
-			req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
-			wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			req: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+			wantReq: testutil.NewRequest(
+				testutil.WithPrincipal("abc@project.iam.gserviceaccount.com"),
+				testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
 		},
 		{
 			name:          "invalid_config_file_should_error",
@@ -184,8 +192,10 @@ func TestFromConfig(t *testing.T) {
 				},
 			},
 		},
-		req:     testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
-		wantReq: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+		req: testutil.NewRequest(testutil.WithPrincipal("abc@project.iam.gserviceaccount.com")),
+		wantReq: testutil.NewRequest(
+			testutil.WithPrincipal("abc@project.iam.gserviceaccount.com"),
+			testutil.WithMode(api.AuditLogRequest_FAIL_CLOSE)),
 	}, {
 		name:          "invalid_config_error",
 		cfg:           &api.Config{}, // Empty config is invalid

--- a/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/config/AuditLoggingConfiguration.java
+++ b/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/config/AuditLoggingConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.abcxyz.lumberjack.auditlogclient.config;
 
+import com.abcxyz.lumberjack.auditlogclient.utils.ConfigUtils;
 import com.abcxyz.lumberjack.v1alpha1.AuditLogRequest.LogMode;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -31,6 +32,8 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class AuditLoggingConfiguration {
+  private static final String LOG_MODE_ENV_KEY = "AUDIT_CLIENT_LOG_MODE";
+
   private String version;
   private BackendContext backend;
 
@@ -55,8 +58,13 @@ public class AuditLoggingConfiguration {
     return conditions == null ? new Filters() : conditions.getFilters();
   }
 
+  // Defaul null and LOG_MODE_UNSPECIFIED log mode to FAIL_CLOSE.
   public LogMode getLogMode() {
-    return logMode == null ? LogMode.FAIL_CLOSE : logMode;
+    if (logMode == null) {
+      logMode = LogMode.FAIL_CLOSE;
+    }
+    logMode = LogMode.valueOf(ConfigUtils.getEnvOrDefault(LOG_MODE_ENV_KEY, logMode.toString()));
+    return logMode == LogMode.LOG_MODE_UNSPECIFIED ? LogMode.FAIL_CLOSE : logMode;
   }
 
   public Justification getJustificaiton() {

--- a/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/utils/ConfigUtils.java
+++ b/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/utils/ConfigUtils.java
@@ -23,10 +23,7 @@ public class ConfigUtils {
     // no-op
   }
 
-  /**
-   * Returns whether we should fail close on errors. Unspecified (LOG_MODE_UNSPECIFIED) is handled
-   * equivalently to BEST_EFFORT, which is to not fail close.
-   */
+  /** Returns whether we should fail close on errors. */
   public static boolean shouldFailClose(LogMode logMode) {
     return logMode.equals(LogMode.FAIL_CLOSE);
   }

--- a/clients/java-logger/library/src/test/java/com/abcxyz/lumberjack/auditlogclient/modules/CloudLoggingModuleTest.java
+++ b/clients/java-logger/library/src/test/java/com/abcxyz/lumberjack/auditlogclient/modules/CloudLoggingModuleTest.java
@@ -35,10 +35,17 @@ class CloudLoggingModuleTest {
   }
 
   @Test
-  void whenLogModeIsUnspecifiedLoggingIsAsync() {
-    AuditLoggingConfigurationTestModule.logMode = LogMode.LOG_MODE_UNSPECIFIED;
+  void whenLogModeIsBestEffortLoggingIsAsync() {
+    AuditLoggingConfigurationTestModule.logMode = LogMode.BEST_EFFORT;
     Logging logging = injector().getInstance(Logging.class);
     assertThat(logging.getWriteSynchronicity()).isEqualTo(Synchronicity.ASYNC);
+  }
+
+  @Test
+  void whenLogModeIsUnspecifiedLoggingIsSync() {
+    AuditLoggingConfigurationTestModule.logMode = LogMode.LOG_MODE_UNSPECIFIED;
+    Logging logging = injector().getInstance(Logging.class);
+    assertThat(logging.getWriteSynchronicity()).isEqualTo(Synchronicity.SYNC);
   }
 
   @Test


### PR DESCRIPTION
1. Updated java code since we want to treat LOG_MODE_UNSPECIFIED as FAIL_CLOSE as a safer default, to be consistent with go client. 
2. fixed go config validate and setDefault not called.
3. go client does not pick up the logmode, added via WithLogMode.