### PR TITLE
fix: omit timestamp when creating logentry when no timestamp is provided 

### DIFF
--- a/clients/go/pkg/cloudlogging/processor.go
+++ b/clients/go/pkg/cloudlogging/processor.go
@@ -129,7 +129,10 @@ func (p *Processor) Process(ctx context.Context, logReq *api.AuditLogRequest) er
 		Payload:   logReq.Payload,
 		Labels:    logReq.Labels,
 		Operation: logReq.Operation,
-		Timestamp: logReq.Timestamp.AsTime(),
+	}
+
+	if logReq.Timestamp != nil {
+		logEntry.Timestamp = logReq.Timestamp.AsTime()
 	}
 
 	bestEffort := p.bestEffort

--- a/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/processor/CloudLoggingProcessor.java
+++ b/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/processor/CloudLoggingProcessor.java
@@ -31,7 +31,6 @@ import com.google.cloud.logging.Payload;
 import com.google.inject.Inject;
 import com.google.logging.v2.LogEntryOperation;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.JsonFormat;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;

--- a/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/processor/CloudLoggingProcessor.java
+++ b/clients/java-logger/library/src/main/java/com/abcxyz/lumberjack/auditlogclient/processor/CloudLoggingProcessor.java
@@ -80,7 +80,7 @@ public class CloudLoggingProcessor implements LogBackend {
                       .setLast(operation.getLast())
                       .build());
 
-      if (!(auditLogRequest.getTimestamp()).equals(Timestamp.getDefaultInstance())) {
+      if (auditLogRequest.hasTimestamp()) {
         entryBuilder.setTimestamp(
             Instant.ofEpochSecond(
                 auditLogRequest.getTimestamp().getSeconds(),


### PR DESCRIPTION
omit timestamp when creating logentry when no timestamp is provided, cloud logging will automatically fill in the timestamp field.