### PR TITLE
chore: update go client to use pkg/gcputil

### DIFF
--- a/clients/go/pkg/cloudlogging/processor.go
+++ b/clients/go/pkg/cloudlogging/processor.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"fmt"
 
-	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/logging"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	api "github.com/abcxyz/lumberjack/clients/go/apis/v1alpha1"
+	"github.com/abcxyz/pkg/gcputil"
 	"github.com/hashicorp/go-multierror"
 )
 
@@ -77,10 +77,7 @@ func NewProcessor(ctx context.Context, opts ...Option) (*Processor, error) {
 
 	// If the options didn't provide a Cloud Logging client, create one.
 	if p.client == nil {
-		projectID, err := metadata.ProjectID()
-		if err != nil {
-			return nil, fmt.Errorf("error getting project ID from metadata to initialize the default Cloud Logging client: %w", err)
-		}
+		projectID := gcputil.ProjectID(ctx)
 		client, err := logging.NewClient(ctx, projectID)
 		if err != nil {
 			return nil, fmt.Errorf("error creating the default Cloud Logging client for project %v: %w", projectID, err)


### PR DESCRIPTION
The cloud logging processor relies on the metadta server to resolve the project id if no logging client is provided. This causes issues with local testing of services that use the go client. Switched to the gcputil ProjectID function in pkg which checks the environment first and then falls back on the metadata server.