### PR TITLE
chore: update go client readme

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -7,7 +7,7 @@ For now, to use the module:
 1.  Get the module
 
     ```
-    go get -u github.com/abcxyz/lumberjack/clients/go
+    go get -u github.com/abcxyz/lumberjack
     ```
 
 1.  To use the package in code (with alias)


### PR DESCRIPTION
with `go get -u github.com/abcxyz/lumberjack/clients/go` I will get an outdated version `github.com/abcxyz/lumberjack/clients/go v0.0.0-20220923211834-05145c811069`, I guess it is because we only have one mod file and we should use `github.com/abcxyz/lumberjack` module?