### PR TITLE
Slightly increase integration test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,7 @@ jobs:
           AUDIT_CLIENT_TEST_PRIVATE_KEY_PATH: '${{ github.workspace }}/integration/testrunner/test_private_key'
         run: |-
           export AUDIT_CLIENT_TEST_IDTOKEN="$(gcloud auth print-identity-token --impersonate-service-account=${{ env.WIF_SERVICE_ACCOUNT }} --include-email)"
-          go test ./integration/testrunner -timeout=15m
+          go test ./integration/testrunner -timeout=20m
 
       - name: 'Cleanup the infrastructure'
         if: '${{ always() }}'

--- a/integration/testrunner/config.go
+++ b/integration/testrunner/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	GRPCEndpoints           string        `env:"GRPC_ENDPOINTS,required"`
 	LogRoutingWait          time.Duration `env:"AUDIT_CLIENT_TEST_AUDIT_LOG_ROUTING_WAIT,default=5s"`
 	MaxAuditLogRequestTries uint64        `env:"AUDIT_CLIENT_TEST_MAX_AUDIT_LOG_REQUEST_TRIES,default=4"`
-	MaxDBQueryTries         uint64        `env:"AUDIT_CLIENT_TEST_MAX_DB_QUERY_TRIES,default=60"`
+	MaxDBQueryTries         uint64        `env:"AUDIT_CLIENT_TEST_MAX_DB_QUERY_TRIES,default=100"`
 	JustificationSubject    string        `env:"AUDIT_CLIENT_TEST_JUSTIFICATION_SUB,required"`
 	IDToken                 string        `env:"AUDIT_CLIENT_TEST_IDTOKEN"`
 	ProjectID               string        `env:"AUDIT_CLIENT_TEST_PROJECT_ID,required"`


### PR DESCRIPTION
Some recently flakiness came up without any code change. Checking logs, there was no real missing logs. The only suspect remaining is that some GCP internal changes caused log routing to take slightly longer time.